### PR TITLE
add synchronisation of transactions and write unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Java XML Persistence API
     <dependency>
       <groupId>net.robinfriedli</groupId>
       <artifactId>JXP</artifactId>
-      <version>1.3</version>
+      <version>1.4</version>
       <type>pom</type>
     </dependency>
 
@@ -20,7 +20,7 @@ Java XML Persistence API
 ## Gradle
 ```gradle
     dependencies {
-        compile 'net.robinfriedli:JXP:1.3'
+        compile 'net.robinfriedli:JXP:1.4'
     }
 
     repositories {
@@ -480,3 +480,16 @@ changes anymore.
 
 StringConverter is a static utility method to convert a String into any other class used by XmlAttribute#getValue and
 the ValueComparator for queries. You can extend to support more classes by using StringConverter#map
+
+## Thread safety
+JXP offers thread safety by synchronising transactions and thus write access across all threads using a global instance
+of the net.robinfriedli.jxp.exec.MutexSync class. This class maps mutex objects to the canonical file path (for persistent
+contexts) or hashcode of the dom Document instance. Furthermore MutexSync automatically counts how many threads are using
+the mutex and drops unused mutexes to avoid leaking memory. Thread safety can only be established when using the propert
+synchronisation modes, all Context#invoke methods use synchronisation unless specified otherwise but when using a custom
+execution mode be sure to add the net.robinfriedli.jxp.exec.MutexSyncMode, this especially important to keep in mind
+when using Context#futureInvoke to run tasks in a separate thread as this method does not normally apply the MutexSyncMode
+because it is commonly used to queue tasks to run after the current transaction within the same thread thus assuming it is
+already running inside a synchronised parent task.
+
+JXP often creates copies of internal collections before iterating for stability in a highly concurrent environment.

--- a/build.gradle
+++ b/build.gradle
@@ -14,16 +14,26 @@ dependencies {
     compile "org.seleniumhq.selenium:selenium-support:3.14.0"
     compile "org.slf4j:slf4j-api:1.7.26"
     compile "net.robinfriedli:StringList:1.5"
+
+    testCompile "org.testng:testng:7.1.0"
+    testCompile "com.google.truth:truth:1.0.1"
 }
 
 group = "net.robinfriedli"
-version = "1.3"
+version = "1.4"
 description = "JXP"
 sourceCompatibility = "8"
+targetCompatibility = "8"
+
+compileJava.options.encoding = "UTF-8"
 
 task sourceJar(type: Jar) {
     classifier 'sources'
     from sourceSets.main.allJava
+}
+
+test {
+    useTestNG()
 }
 
 publishing {
@@ -56,4 +66,9 @@ bintray {
         repo = rootProject.group
         name = "JXP"
     }
+}
+
+tasks.withType(JavaCompile) {
+    options.compilerArgs << '-Xlint:unchecked'
+    options.deprecation = true
 }

--- a/src/main/java/net/robinfriedli/jxp/api/AbstractXmlElement.java
+++ b/src/main/java/net/robinfriedli/jxp/api/AbstractXmlElement.java
@@ -13,11 +13,12 @@ import javax.annotation.Nullable;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import net.robinfriedli.jxp.events.AttributeChangingEvent;
+import net.robinfriedli.jxp.events.AttributeDeletedEvent;
 import net.robinfriedli.jxp.events.ElementChangingEvent;
 import net.robinfriedli.jxp.events.ElementCreatedEvent;
 import net.robinfriedli.jxp.events.ElementDeletingEvent;
 import net.robinfriedli.jxp.events.RecursiveDeletingEvent;
-import net.robinfriedli.jxp.events.ValueChangingEvent;
+import net.robinfriedli.jxp.events.TextContentChangingEvent;
 import net.robinfriedli.jxp.events.VirtualEvent;
 import net.robinfriedli.jxp.exceptions.PersistException;
 import net.robinfriedli.jxp.persist.Context;
@@ -36,7 +37,7 @@ public abstract class AbstractXmlElement implements XmlElement {
 
     private final String tagName;
 
-    private final List<XmlAttribute> attributes;
+    private final Map<String, XmlAttribute> attributes;
 
     private final List<XmlElement> subElements;
 
@@ -81,9 +82,9 @@ public abstract class AbstractXmlElement implements XmlElement {
         this.textContent = textContent;
         this.state = State.CONCEPTION;
 
-        List<XmlAttribute> attributes = Lists.newArrayList();
+        Map<String, XmlAttribute> attributes = new HashMap<>();
         for (String attributeName : attributeMap.keySet()) {
-            attributes.add(new XmlAttribute(this, attributeName, attributeMap.get(attributeName)));
+            attributes.put(attributeName, new XmlAttribute(this, attributeName, attributeMap.get(attributeName)));
         }
         this.attributes = attributes;
 
@@ -104,10 +105,10 @@ public abstract class AbstractXmlElement implements XmlElement {
         this.context = context;
         this.state = State.CLEAN;
 
-        List<XmlAttribute> attributes = Lists.newArrayList();
+        Map<String, XmlAttribute> attributes = new HashMap<>();
         Map<String, String> attributeMap = ElementUtils.getAttributes(element);
         for (String attributeName : attributeMap.keySet()) {
-            attributes.add(new XmlAttribute(this, attributeName, attributeMap.get(attributeName)));
+            attributes.put(attributeName, new XmlAttribute(this, attributeName, attributeMap.get(attributeName)));
         }
         this.attributes = attributes;
 
@@ -149,12 +150,12 @@ public abstract class AbstractXmlElement implements XmlElement {
         Map<String, String> attributeMap = new HashMap<>();
 
         if (copySubElements && hasSubElements()) {
-            for (XmlElement subElement : this.subElements) {
+            for (XmlElement subElement : Lists.newArrayList(this.subElements)) {
                 subElements.add(subElement.copy(true, instantiateContributedClass));
             }
         }
 
-        for (XmlAttribute attribute : attributes) {
+        for (XmlAttribute attribute : Lists.newArrayList(attributes.values())) {
             attributeMap.put(attribute.getAttributeName(), attribute.getValue());
         }
 
@@ -212,7 +213,14 @@ public abstract class AbstractXmlElement implements XmlElement {
     @Override
     public void setParent(XmlElement parent) {
         if (this.parent != null) {
-            throw new IllegalStateException(toString() + " already has a parent. Remove it from the old parent first.");
+            if (this.parent instanceof UninitializedParent) {
+                UninitializedParent uninitializedParent = (UninitializedParent) this.parent;
+                if (uninitializedParent.getChild() != this) {
+                    throw new IllegalArgumentException("The provided UninitializedParent is a parent of a different element");
+                }
+            } else {
+                throw new IllegalStateException(toString() + " already has a parent. Remove it from the old parent first.");
+            }
         }
 
         this.parent = parent;
@@ -248,12 +256,17 @@ public abstract class AbstractXmlElement implements XmlElement {
 
     @Override
     public List<XmlAttribute> getAttributes() {
+        return Lists.newArrayList(attributes.values());
+    }
+
+    @Override
+    public Map<String, XmlAttribute> getAttributeMap() {
         return attributes;
     }
 
     @Override
     public XmlAttribute getAttribute(String attributeName) {
-        List<XmlAttribute> foundAttributes = attributes.stream()
+        List<XmlAttribute> foundAttributes = Lists.newArrayList(attributes.values()).stream()
             .filter(a -> a.getAttributeName().equals(attributeName))
             .collect(Collectors.toList());
 
@@ -267,8 +280,8 @@ public abstract class AbstractXmlElement implements XmlElement {
     }
 
     @Override
-    public void addAttribute(XmlAttribute attribute) {
-        attributes.add(attribute);
+    public void removeAttribute(String attributeName) {
+        getAttribute(attributeName).remove();
     }
 
     @Override
@@ -369,7 +382,7 @@ public abstract class AbstractXmlElement implements XmlElement {
 
     @Override
     public <E extends XmlElement> E getSubElement(String id, Class<E> type) {
-        List<E> foundSubElements = getSubElements().stream()
+        List<E> foundSubElements = Lists.newArrayList(getSubElements()).stream()
             .filter(subElem -> type.isInstance(subElem) && subElem.getId() != null && subElem.getId().equals(id))
             .map(type::cast)
             .collect(Collectors.toList());
@@ -406,7 +419,7 @@ public abstract class AbstractXmlElement implements XmlElement {
 
     @Override
     public boolean hasSubElement(String id) {
-        return getSubElements().stream().anyMatch(subElem -> subElem.getId() != null && subElem.getId().equals(id));
+        return Lists.newArrayList(getSubElements()).stream().anyMatch(subElem -> subElem.getId() != null && subElem.getId().equals(id));
     }
 
     @Override
@@ -417,8 +430,7 @@ public abstract class AbstractXmlElement implements XmlElement {
     @Override
     public void setTextContent(String textContent) {
         String oldValue = String.valueOf(getTextContent());
-        ValueChangingEvent<String> valueChangingEvent = new ValueChangingEvent<>(this, oldValue, textContent);
-        addChange(ElementChangingEvent.textContentChange(valueChangingEvent));
+        addChange(new TextContentChangingEvent(this, oldValue, textContent));
     }
 
     @Override
@@ -506,82 +518,14 @@ public abstract class AbstractXmlElement implements XmlElement {
         return changes != null && !changes.isEmpty();
     }
 
-    @Deprecated
-    @Override
-    public ElementChangingEvent getFirstChange() {
-        return hasChanges() ? getChanges().get(0) : null;
-    }
-
-    @Deprecated
-    @Override
-    public ElementChangingEvent getLastChange() {
-        List<ElementChangingEvent> changes = getChanges();
-        return hasChanges() ? changes.get(changes.size() - 1) : null;
-    }
-
-    @Deprecated
-    @Override
-    public AttributeChangingEvent getFirstAttributeChange(String attributeName) {
-        if (!hasAttribute(attributeName)) {
-            throw new IllegalArgumentException(toString() + " does not have an attribute named " + attributeName);
-        }
-
-        if (hasChanges()) {
-            for (ElementChangingEvent change : getChanges()) {
-                if (change.attributeChanged(attributeName)) {
-                    return change.getAttributeChange(attributeName);
-                }
-            }
-        }
-
-        return null;
-    }
-
-    @Deprecated
-    @Override
-    public AttributeChangingEvent getLastAttributeChange(String attributeName) {
-        if (!hasAttribute(attributeName)) {
-            throw new IllegalArgumentException(toString() + " does not have an attribute named " + attributeName);
-        }
-
-        AttributeChangingEvent attributeChange = null;
-        if (hasChanges()) {
-            for (ElementChangingEvent change : getChanges()) {
-                if (change.attributeChanged(attributeName)) {
-                    attributeChange = change.getAttributeChange(attributeName);
-                }
-            }
-        }
-
-        return attributeChange;
-    }
-
     @Override
     public boolean attributeChanged(String attributeName) {
-        return getFirstAttributeChange(attributeName) != null;
-    }
-
-    @Deprecated
-    @Override
-    public ValueChangingEvent<String> getFirstTextContentChange() {
-        for (ElementChangingEvent change : getChanges()) {
-            if (change.textContentChanged()) {
-                return change.getChangedTextContent();
-            }
-        }
-
-        return null;
+        return Lists.newArrayList(changes).stream().anyMatch(change -> change.attributeChanged(attributeName));
     }
 
     @Override
     public boolean textContentChanged() {
-        return getFirstTextContentChange() != null;
-    }
-
-    @Deprecated
-    @Override
-    public void clearChanges() {
-        this.changes.clear();
+        return Lists.newArrayList(changes).stream().anyMatch(change -> change.getChangedTextContent() != null);
     }
 
     @Override
@@ -611,15 +555,15 @@ public abstract class AbstractXmlElement implements XmlElement {
 
     @Override
     public <E extends XmlElement> List<E> getInstancesOf(Class<E> c) {
-        return getSubElements().stream()
+        return Lists.newArrayList(getSubElements()).stream()
             .filter(c::isInstance)
             .map(c::cast)
             .collect(Collectors.toList());
     }
 
     @Override
-    public <E extends XmlElement> List<E> getInstancesOf(Class<E> c, Class... ignoredSubClasses) {
-        return getSubElements().stream()
+    public <E extends XmlElement> List<E> getInstancesOf(Class<E> c, Class<?>... ignoredSubClasses) {
+        return Lists.newArrayList(getSubElements()).stream()
             .filter(elem -> c.isInstance(elem) && Arrays.stream(ignoredSubClasses).noneMatch(clazz -> clazz.isInstance(elem)))
             .map(c::cast)
             .collect(Collectors.toList());
@@ -645,14 +589,23 @@ public abstract class AbstractXmlElement implements XmlElement {
             throw new UnsupportedOperationException("Source of ElementChangingEvent is not this XmlElement. Change can't be applied.");
         }
 
-        if (change.getChangedAttributes() != null) {
-            for (AttributeChangingEvent changedAttribute : change.getChangedAttributes()) {
-                XmlAttribute attributeToChange = changedAttribute.getAttribute();
-                if (isRollback) {
-                    attributeToChange.revertChange(changedAttribute);
-                } else {
-                    attributeToChange.applyChange(changedAttribute);
-                }
+        AttributeChangingEvent attributeChange = change.getAttributeChange();
+        if (attributeChange != null) {
+            XmlAttribute attributeToChange = attributeChange.getAttribute();
+            if (isRollback) {
+                attributeToChange.revertChange(attributeChange);
+            } else {
+                attributeToChange.applyChange(attributeChange);
+            }
+        }
+
+        AttributeDeletedEvent attributeDeletion = change.getAttributeDeletion();
+        if (attributeDeletion != null) {
+            XmlAttribute attribute = attributeDeletion.getAttribute();
+            if (isRollback) {
+                attributes.put(attribute.getAttributeName(), attribute);
+            } else {
+                attributes.remove(attribute.getAttributeName());
             }
         }
 

--- a/src/main/java/net/robinfriedli/jxp/api/JxpBackend.java
+++ b/src/main/java/net/robinfriedli/jxp/api/JxpBackend.java
@@ -2,7 +2,9 @@ package net.robinfriedli.jxp.api;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
+import java.util.Vector;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -16,31 +18,36 @@ import net.robinfriedli.jxp.events.ElementCreatedEvent;
 import net.robinfriedli.jxp.events.ElementDeletingEvent;
 import net.robinfriedli.jxp.events.JxpEventListener;
 import net.robinfriedli.jxp.exceptions.PersistException;
+import net.robinfriedli.jxp.exec.MutexSync;
 import net.robinfriedli.jxp.logging.LoggerSupplier;
 import net.robinfriedli.jxp.persist.BindableCachedContext;
+import net.robinfriedli.jxp.persist.BindableLazyContext;
 import net.robinfriedli.jxp.persist.CachedContext;
 import net.robinfriedli.jxp.persist.Context;
 import net.robinfriedli.jxp.persist.LazyContext;
+import net.robinfriedli.jxp.persist.StaticXmlParser;
 import net.robinfriedli.jxp.persist.Transaction;
 import org.w3c.dom.Document;
 
 public class JxpBackend {
 
+    private static MutexSync<String> mutexSync = new MutexSync<>();
+
     private final List<Context> contexts;
     private final List<Context.BindableContext> boundContexts;
-    private final List<JxpEventListener> listeners;
+    private final Vector<JxpEventListener> listeners;
     private final Logger logger;
     private final DefaultContextType defaultContextType;
     private ThreadLocal<Boolean> listenersMuted = ThreadLocal.withInitial(() -> false);
 
-    public JxpBackend(List<JxpEventListener> listeners,
+    public JxpBackend(Vector<JxpEventListener> listeners,
                       DefaultContextType defaultContextType) {
         this(Lists.newArrayList(), Lists.newArrayList(), listeners, defaultContextType);
     }
 
     public JxpBackend(List<Context> contexts,
                       List<Context.BindableContext> boundContexts,
-                      List<JxpEventListener> listeners,
+                      Vector<JxpEventListener> listeners,
                       DefaultContextType defaultContextType) {
         this.contexts = contexts;
         this.boundContexts = boundContexts;
@@ -62,37 +69,45 @@ public class JxpBackend {
     }
 
     /**
-     * @param document the DOM document
-     * @return either the existing Context for this document that is attached to this JxpBackend instance or a new
-     * Context that will be attached to this JxpBackend
-     */
-    public Context getContext(Document document) {
-        Context existingContext = getExistingContext(document);
-
-        if (existingContext != null) {
-            return existingContext;
-        } else {
-            Context context = defaultContextType.getContext(this, document, logger);
-            contexts.add(context);
-            return context;
-        }
-    }
-
-    /**
      * @param file the XML file
      * @return either the existing Context for this file that is attached to this JxpBackend instance or a new Context
      * that will be attached to this JxpBackend
      */
     public Context getContext(File file) {
-        Context existingContext = getExistingContext(file);
+        String canonicalPath = getCanonicalPath(file);
 
-        if (existingContext != null) {
-            return existingContext;
-        } else {
-            Context context = defaultContextType.getContext(this, file, logger);
-            contexts.add(context);
-            return context;
-        }
+        return mutexSync.evaluate(canonicalPath, () -> {
+            Context existingContext = getExistingContext(file);
+
+            if (existingContext != null) {
+                return existingContext;
+            } else {
+                Context context = defaultContextType.getContext(this, file, logger);
+                contexts.add(context);
+                return context;
+            }
+        });
+    }
+
+    /**
+     * @param document the DOM document
+     * @return either the existing Context for this document that is attached to this JxpBackend instance or a new
+     * Context that will be attached to this JxpBackend
+     */
+    public Context getContext(Document document) {
+        String mutexKey = String.valueOf(document.hashCode());
+
+        return mutexSync.evaluate(mutexKey, () -> {
+            Context existingContext = getExistingContext(document);
+
+            if (existingContext != null) {
+                return existingContext;
+            } else {
+                Context context = defaultContextType.getContext(this, document, logger);
+                contexts.add(context);
+                return context;
+            }
+        });
     }
 
     @Nullable
@@ -101,35 +116,21 @@ public class JxpBackend {
     }
 
     /**
-     * @param document the DOM document
-     * @return the existing Context for this document that is attached to this JxpBackend
-     */
-    @Nullable
-    public Context getExistingContext(Document document) {
-        List<Context> found = contexts.stream().filter(c -> c.getDocument().equals(document)).collect(Collectors.toList());
-
-        if (found.size() == 1) {
-            return found.get(0);
-        } else if (found.size() > 1) {
-            throw new IllegalStateException("More than one Context for document " + document);
-        }
-
-        return null;
-    }
-
-    /**
+     * Find an existing Context for the canonical path of the provided file. This method operates on a copy of the current
+     * state of the contexts list.
+     *
      * @param file the XML file
      * @return the existing Context for this XML file that is attached to this JxpBackend
      */
     @Nullable
     public Context getExistingContext(File file) {
-        List<Context> found = contexts
+        List<Context> found = Lists.newArrayList(contexts)
             .stream()
             .filter(c -> {
                 try {
                     return c.getFile() != null && c.getFile().getCanonicalPath().equals(file.getCanonicalPath());
                 } catch (IOException e) {
-                    throw new PersistException(e);
+                    throw new PersistException("could not get canonical path for file", e);
                 }
             })
             .collect(Collectors.toList());
@@ -143,18 +144,28 @@ public class JxpBackend {
         return null;
     }
 
-    public Context requireExistingContext(String path) {
-        return requireExistingContext(new File(path));
+    /**
+     * Find an existing Context for the provided Document instance. This method operates on a copy of the current state
+     * of the contexts list.
+     *
+     * @param document the DOM document
+     * @return the existing Context for this document that is attached to this JxpBackend
+     */
+    @Nullable
+    public Context getExistingContext(Document document) {
+        List<Context> found = Lists.newArrayList(contexts).stream().filter(c -> c.getDocument().equals(document)).collect(Collectors.toList());
+
+        if (found.size() == 1) {
+            return found.get(0);
+        } else if (found.size() > 1) {
+            throw new IllegalStateException("More than one Context for document " + document);
+        }
+
+        return null;
     }
 
-    public Context requireExistingContext(Document document) {
-        Context context = getExistingContext(document);
-
-        if (context != null) {
-            return context;
-        } else {
-            throw new IllegalStateException("No Context for document " + document);
-        }
+    public Context requireExistingContext(String path) {
+        return requireExistingContext(new File(path));
     }
 
     public Context requireExistingContext(File file) {
@@ -167,16 +178,18 @@ public class JxpBackend {
         }
     }
 
-    public boolean hasContext(String path) {
-        return hasContext(new File(path));
+    public Context requireExistingContext(Document document) {
+        Context context = getExistingContext(document);
+
+        if (context != null) {
+            return context;
+        } else {
+            throw new IllegalStateException("No Context for document " + document);
+        }
     }
 
-    /**
-     * @param document the DOM document
-     * @return true if this JxpBackend has an attached Context for this DOM document
-     */
-    public boolean hasContext(Document document) {
-        return contexts.stream().anyMatch(c -> c.getDocument().equals(document));
+    public boolean hasContext(String path) {
+        return hasContext(new File(path));
     }
 
     /**
@@ -184,7 +197,7 @@ public class JxpBackend {
      * @return true if this JxpBackend has an attached Context for this XML file
      */
     public boolean hasContext(File file) {
-        return contexts.stream().anyMatch(c -> {
+        return Lists.newArrayList(contexts).stream().anyMatch(c -> {
             try {
                 return c.getFile() != null && c.getFile().getCanonicalPath().equals(file.getCanonicalPath());
             } catch (IOException e) {
@@ -194,11 +207,19 @@ public class JxpBackend {
     }
 
     /**
+     * @param document the DOM document
+     * @return true if this JxpBackend has an attached Context for this DOM document
+     */
+    public boolean hasContext(Document document) {
+        return Lists.newArrayList(contexts).stream().anyMatch(c -> c.getDocument().equals(document));
+    }
+
+    /**
      * @param boundObject the mapped object
      * @return true if this JxpBackend has a Context mapped to this object
      */
     public boolean hasBoundContext(Object boundObject) {
-        return boundContexts.stream().anyMatch(ctx -> ctx.getBindingObject().equals(boundObject));
+        return Lists.newArrayList(boundContexts).stream().anyMatch(ctx -> ctx.getBindingObject().equals(boundObject));
     }
 
     public <E> Context.BindableContext<E> requireBoundContext(E boundObject) {
@@ -219,7 +240,7 @@ public class JxpBackend {
     @SuppressWarnings("unchecked")
     @Nullable
     public <E> Context.BindableContext<E> getBoundContext(E boundObject) {
-        List<Context.BindableContext> found = boundContexts
+        List<Context.BindableContext> found = Lists.newArrayList(boundContexts)
             .stream()
             .filter(c -> c.getBindingObject().equals(boundObject))
             .collect(Collectors.toList());
@@ -239,9 +260,17 @@ public class JxpBackend {
     }
 
     /**
-     * Create a new CachedContext without attaching it to this JxpBackend. This allows several contexts for the same
-     * document in different threads, which is only safe for read-only operations, so be careful not to have threads override
-     * changes made by a different thread.
+     * Create a new CachedContext without attaching it to this JxpBackend.
+     *
+     * @param file the file to create a context for
+     * @return the created cached context
+     */
+    public CachedContext createCachedContext(File file) {
+        return new CachedContext(this, file, logger);
+    }
+
+    /**
+     * Create a new CachedContext without attaching it to this JxpBackend.
      *
      * @param document the document to create a context for
      * @return the created cached context
@@ -251,15 +280,14 @@ public class JxpBackend {
     }
 
     /**
-     * Create a new CachedContext without attaching it to this JxpBackend. This allows several contexts for the same
-     * file in different threads, which is only safe for read-only operations, so be careful not to have threads override
-     * changes made by a different thread.
+     * Create a new CachedContext without attaching it to this JxpBackend. This implementation constructs a {@link Document} for the provided {@link InputStream}
+     * and then calls {@link #createCachedContext(Document)}. This is useful as a shorthand for classpath resources.
      *
-     * @param file the file to create a context for
+     * @param inputStream the InputStream to create a context for
      * @return the created cached context
      */
-    public CachedContext createCachedContext(File file) {
-        return new CachedContext(this, file, logger);
+    public CachedContext createCachedContext(InputStream inputStream) {
+        return createCachedContext(StaticXmlParser.parseDocument(inputStream));
     }
 
     public LazyContext createLazyContext(String path) {
@@ -267,9 +295,17 @@ public class JxpBackend {
     }
 
     /**
-     * Create a new LazyContext without attaching it to this JxpBackend. This allows several contexts for the same
-     * file in different threads, which is only safe for read-only operations, so be careful not to have threads override
-     * changes made by a different thread.
+     * Create a new LazyContext without attaching it to this JxpBackend.
+     *
+     * @param file the file to create a context for
+     * @return the created lazy context
+     */
+    public LazyContext createLazyContext(File file) {
+        return new LazyContext(this, file, logger);
+    }
+
+    /**
+     * Create a new LazyContext without attaching it to this JxpBackend.
      *
      * @param document the document to create a context for
      * @return the created lazy context
@@ -279,15 +315,102 @@ public class JxpBackend {
     }
 
     /**
-     * Create a new LazyContext without attaching it to this JxpBackend. This allows several contexts for the same
-     * file in different threads, which is only safe for read-only operations, so be careful not to have threads override
-     * changes made by a different thread.
+     * Create a new LazyContext without attaching it to this JxpBackend. This implementation constructs a {@link Document} for the provided {@link InputStream}
+     * and then calls {@link #createCachedContext(Document)}. This is useful as a shorthand for classpath resources.
      *
-     * @param file the file to create a context for
-     * @return the created lazy context
+     * @param inputStream the InputStream to create a context for
+     * @return the created cached context
      */
-    public LazyContext createLazyContext(File file) {
-        return new LazyContext(this, file, logger);
+    public LazyContext createLazyContext(InputStream inputStream) {
+        return createLazyContext(StaticXmlParser.parseDocument(inputStream));
+    }
+
+    public Context createContext(String path) {
+        return createContext(new File(path));
+    }
+
+    public Context createContext(File file) {
+        return defaultContextType.getContext(this, file, logger);
+    }
+
+    public Context createContext(Document document) {
+        return defaultContextType.getContext(this, document, logger);
+    }
+
+    public Context createContext(InputStream inputStream) {
+        return createContext(StaticXmlParser.parseDocument(inputStream));
+    }
+
+    public <E> Context.BindableContext<E> createBoundCachedContext(String path, E objectToBind) {
+        return createBoundCachedContext(new File(path), objectToBind);
+    }
+
+    /**
+     * Create a {@link CachedContext} that is "bound" to the provided object. Meaning, once added to the JxpBackend, it
+     * can be retrieved via {@link #getBoundContext(Object)} with any Object that matches the bound object according to
+     * {@link Object#equals(Object)}.
+     *
+     * @param file         the persistent file to create the Context for
+     * @param objectToBind the object to bind
+     * @param <E>          the type of the object
+     * @return the created BindableContext (not attached to this JxpBackend yet)
+     */
+    public <E> Context.BindableContext<E> createBoundCachedContext(File file, E objectToBind) {
+        return new BindableCachedContext<>(this, file, objectToBind, logger);
+    }
+
+    /**
+     * Create a {@link CachedContext} that is "bound" to the provided object. Meaning, once added to the JxpBackend, it
+     * can be retrieved via {@link #getBoundContext(Object)} with any Object that matches the bound object according to
+     * {@link Object#equals(Object)}.
+     *
+     * @param document     the dom document to create the Context for
+     * @param objectToBind the object to bind
+     * @param <E>          the type of the object
+     * @return the created BindableContext (not attached to this JxpBackend yet)
+     */
+    public <E> Context.BindableContext<E> createBoundCachedContext(Document document, E objectToBind) {
+        return new BindableCachedContext<>(this, document, objectToBind, logger);
+    }
+
+    public <E> Context.BindableContext<E> createBoundCachedContext(InputStream inputStream, E objectToBind) {
+        return createBoundCachedContext(StaticXmlParser.parseDocument(inputStream), objectToBind);
+    }
+
+    public <E> Context.BindableContext<E> createBoundLazyContext(String path, E objectToBind) {
+        return createBoundLazyContext(new File(path), objectToBind);
+    }
+
+    /**
+     * Create a {@link LazyContext} that is "bound" to the provided object. Meaning, once added to the JxpBackend, it
+     * can be retrieved via {@link #getBoundContext(Object)} with any Object that matches the bound object according to
+     * {@link Object#equals(Object)}.
+     *
+     * @param file         the persistent file to create the Context for
+     * @param objectToBind the object to bind
+     * @param <E>          the type of the object
+     * @return the created BindableContext (not attached to this JxpBackend yet)
+     */
+    public <E> Context.BindableContext<E> createBoundLazyContext(File file, E objectToBind) {
+        return new BindableLazyContext<>(this, file, objectToBind, logger);
+    }
+
+    /**
+     * Create a {@link LazyContext} that is "bound" to the provided object. Meaning, once added to the JxpBackend, it
+     * can be retrieved via {@link #getBoundContext(Object)} with any Object that matches the bound object according to
+     * {@link Object#equals(Object)}.
+     *
+     * @param document     the dom document to create the Context for
+     * @param objectToBind the object to bind
+     * @param <E>          the type of the object
+     * @return the created BindableContext (not attached to this JxpBackend yet)
+     */
+    public <E> Context.BindableContext<E> createBoundLazyContext(Document document, E objectToBind) {
+        return new BindableLazyContext<>(this, document, objectToBind, logger);
+    }
+
+    public <E> Context.BindableContext<E> createBoundLazyContext(InputStream inputStream, E objectToBind) {
+        return createBoundLazyContext(StaticXmlParser.parseDocument(inputStream), objectToBind);
     }
 
     public <E> Context.BindableContext<E> createBoundContext(String path, E objectToBind) {
@@ -295,19 +418,21 @@ public class JxpBackend {
     }
 
     public <E> Context.BindableContext<E> createBoundContext(Document document, E objectToBind) {
-        return new BindableCachedContext<>(this, document, objectToBind, logger);
+        return defaultContextType.getBindableContext(this, document, objectToBind, logger);
+    }
+
+    public <E> Context.BindableContext<E> createBoundContext(InputStream inputStream, E objectToBind) {
+        return createBoundContext(StaticXmlParser.parseDocument(inputStream), objectToBind);
     }
 
     /**
-     * Create a new BoundContext without attaching it to this JxpBackend. This allows several contexts for the same
-     * file in different threads, which is only safe for read-only operations, so be careful not to have threads override
-     * changes made by a different thread.
+     * Create a new BoundContext without attaching it to this JxpBackend.
      *
      * @param file the file to create a context for
      * @return the created bound context
      */
     public <E> Context.BindableContext<E> createBoundContext(File file, E objectToBind) {
-        return new BindableCachedContext<>(this, file, objectToBind, logger);
+        return defaultContextType.getBindableContext(this, file, objectToBind, logger);
     }
 
     /**
@@ -316,20 +441,22 @@ public class JxpBackend {
      *
      * @param context the context to attach
      */
+    @SuppressWarnings("rawtypes")
     public void attachContext(Context context) {
-        if (context.isPersistent() && hasContext(context.getFile())) {
-            throw new PersistException("There already is a Context for file " + context.getFile());
-        } else if (hasContext(context.getDocument())) {
-            throw new PersistException("There already is a Context for document " + context.getDocument());
-        }
-
         if (context instanceof Context.BindableContext) {
-            boundContexts.add((Context.BindableContext) context);
+            attachContext((Context.BindableContext) context);
         } else {
+            if (context.isPersistent() && hasContext(context.getFile())) {
+                throw new PersistException("There already is a Context for file " + context.getFile());
+            } else if (hasContext(context.getDocument())) {
+                throw new PersistException("There already is a Context for document " + context.getDocument());
+            }
+
             contexts.add(context);
         }
     }
 
+    @SuppressWarnings("rawtypes")
     public void attachContext(Context.BindableContext context) {
         if (hasBoundContext(context.getBindingObject())) {
             throw new PersistException("There already is a Context bound to object equal to " + context.getBindingObject());
@@ -369,6 +496,28 @@ public class JxpBackend {
 
     public void removeContext(Context.BindableContext context) {
         boundContexts.remove(context);
+    }
+
+    /**
+     * Clear all "regular" unbound contexts
+     */
+    public void clearContexts() {
+        contexts.clear();
+    }
+
+    /**
+     * Clear all bound contexts
+     */
+    public void clearBoundContexts() {
+        boundContexts.clear();
+    }
+
+    /**
+     * Clear all contexts attached to this JxpBackend, bound and unbound.
+     */
+    public void clearAllContexts() {
+        clearContexts();
+        clearBoundContexts();
     }
 
     public <E> void removeBoundContext(E boundObject) {
@@ -432,6 +581,17 @@ public class JxpBackend {
         };
     }
 
+    private String getCanonicalPath(File file) {
+        String canonicalPath;
+        try {
+            canonicalPath = file.getCanonicalPath();
+        } catch (IOException e) {
+            throw new PersistException("Could not get canonical path of file", e);
+        }
+
+        return canonicalPath;
+    }
+
     public enum DefaultContextType {
 
         CACHED() {
@@ -443,6 +603,16 @@ public class JxpBackend {
             @Override
             public Context getContext(JxpBackend jxpBackend, Document document, Logger logger) {
                 return new CachedContext(jxpBackend, document, logger);
+            }
+
+            @Override
+            public <E> Context.BindableContext<E> getBindableContext(JxpBackend jxpBackend, File file, E bindingObject, Logger logger) {
+                return new BindableCachedContext<>(jxpBackend, file, bindingObject, logger);
+            }
+
+            @Override
+            public <E> Context.BindableContext<E> getBindableContext(JxpBackend jxpBackend, Document document, E bindingObject, Logger logger) {
+                return new BindableCachedContext<>(jxpBackend, document, bindingObject, logger);
             }
         },
 
@@ -456,11 +626,25 @@ public class JxpBackend {
             public Context getContext(JxpBackend jxpBackend, Document document, Logger logger) {
                 return new LazyContext(jxpBackend, document, logger);
             }
+
+            @Override
+            public <E> Context.BindableContext<E> getBindableContext(JxpBackend jxpBackend, File file, E bindingObject, Logger logger) {
+                return new BindableLazyContext<>(jxpBackend, file, bindingObject, logger);
+            }
+
+            @Override
+            public <E> Context.BindableContext<E> getBindableContext(JxpBackend jxpBackend, Document document, E bindingObject, Logger logger) {
+                return new BindableLazyContext<>(jxpBackend, document, bindingObject, logger);
+            }
         };
 
         public abstract Context getContext(JxpBackend jxpBackend, File file, Logger logger);
 
         public abstract Context getContext(JxpBackend jxpBackend, Document document, Logger logger);
+
+        public abstract <E> Context.BindableContext<E> getBindableContext(JxpBackend jxpBackend, File file, E bindingObject, Logger logger);
+
+        public abstract <E> Context.BindableContext<E> getBindableContext(JxpBackend jxpBackend, Document document, E bindingObject, Logger logger);
 
     }
 }

--- a/src/main/java/net/robinfriedli/jxp/api/JxpBuilder.java
+++ b/src/main/java/net/robinfriedli/jxp/api/JxpBuilder.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.Vector;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -54,7 +55,7 @@ public class JxpBuilder {
     }
 
     public JxpBackend build() {
-        JxpBackend jxpBackend = new JxpBackend(listeners, defaultContextType);
+        JxpBackend jxpBackend = new JxpBackend(new Vector<>(listeners), defaultContextType);
         contextFiles.forEach(jxpBackend::getContext);
         contextDocuments.forEach(jxpBackend::getContext);
 

--- a/src/main/java/net/robinfriedli/jxp/api/StaticXmlElementFactory.java
+++ b/src/main/java/net/robinfriedli/jxp/api/StaticXmlElementFactory.java
@@ -2,6 +2,7 @@ package net.robinfriedli.jxp.api;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,11 +50,16 @@ public class StaticXmlElementFactory {
         return xmlElements;
     }
 
-    public static XmlElement instantiatePersistentXmlElement(Element element, Context context) {
+    public static XmlElement instantiatePersistentXmlElement(Element element, Context context, Element... excludedSubElements) {
         List<Element> subElements = ElementUtils.getChildren(element);
         List<XmlElement> instantiatedSubElems = Lists.newArrayList();
+        List<Element> excludedSubs = Arrays.asList(excludedSubElements);
 
         for (Element subElement : subElements) {
+            if (excludedSubs.contains(subElement)) {
+                continue;
+            }
+
             instantiatedSubElems.add(instantiatePersistentXmlElement(subElement, context));
         }
 

--- a/src/main/java/net/robinfriedli/jxp/api/StringConverter.java
+++ b/src/main/java/net/robinfriedli/jxp/api/StringConverter.java
@@ -14,10 +14,10 @@ public class StringConverter {
 
     static {
         stringConversions.add(new StringConversionContribution<>(0, Integer.class, Integer::parseInt, Object::toString));
-        stringConversions.add(new StringConversionContribution<>(0D, Double.class, Double::new, Object::toString));
-        stringConversions.add(new StringConversionContribution<>(0F, Float.class, Float::new, Object::toString));
-        stringConversions.add(new StringConversionContribution<>(0L, Long.class, Long::new, Object::toString));
-        stringConversions.add(new StringConversionContribution<>(false, Boolean.class, Boolean::new, Object::toString));
+        stringConversions.add(new StringConversionContribution<>(0D, Double.class, Double::parseDouble, Object::toString));
+        stringConversions.add(new StringConversionContribution<>(0F, Float.class, Float::parseFloat, Object::toString));
+        stringConversions.add(new StringConversionContribution<>(0L, Long.class, Long::parseLong, Object::toString));
+        stringConversions.add(new StringConversionContribution<>(false, Boolean.class, Boolean::parseBoolean, Object::toString));
         stringConversions.add(new StringConversionContribution<>(BigDecimal.ZERO, BigDecimal.class, BigDecimal::new, BigDecimal::toString));
         stringConversions.add(new StringConversionContribution<>("", String.class, String::toString, String::toString));
     }

--- a/src/main/java/net/robinfriedli/jxp/api/UninitializedParent.java
+++ b/src/main/java/net/robinfriedli/jxp/api/UninitializedParent.java
@@ -1,0 +1,383 @@
+package net.robinfriedli.jxp.api;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
+
+import net.robinfriedli.jxp.events.ElementChangingEvent;
+import net.robinfriedli.jxp.exceptions.PersistException;
+import net.robinfriedli.jxp.persist.Context;
+import net.robinfriedli.jxp.queries.ResultStream;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+public class UninitializedParent implements XmlElement {
+
+    private final Context context;
+    private final Element element;
+    private final XmlElement child;
+
+    private XmlElement initialized;
+
+    public UninitializedParent(Context context, Element element, XmlElement child) {
+        this.context = context;
+        this.element = element;
+        this.child = child;
+    }
+
+    public XmlElement getChild() {
+        return child;
+    }
+
+    private XmlElement initialize() {
+        XmlElement instantiatedParent = StaticXmlElementFactory.instantiatePersistentXmlElement(element, context, child.requireElement());
+        child.setParent(instantiatedParent);
+        instantiatedParent.getSubElements().add(child);
+        Node parentNode = element.getParentNode();
+
+        if (parentNode instanceof Element && !Objects.equals(parentNode, parentNode.getOwnerDocument().getDocumentElement())) {
+            instantiatedParent.setParent(new UninitializedParent(context, (Element) parentNode, instantiatedParent));
+        }
+
+        initialized = instantiatedParent;
+        return instantiatedParent;
+    }
+
+    public XmlElement getInitialized() {
+        if (initialized == null) {
+            return initialize();
+        }
+
+        return initialized;
+    }
+
+    @Override
+    public void persist(Context context) {
+        getInitialized().persist(context);
+    }
+
+    @Override
+    public void persist(Context context, XmlElement newParent) {
+        getInitialized().persist(context, newParent);
+    }
+
+    @Override
+    public boolean isDetached() {
+        return getInitialized().isDetached();
+    }
+
+    @Override
+    public XmlElement copy(boolean copySubElements, boolean instantiateContributedClass) {
+        return getInitialized().copy(copySubElements, instantiateContributedClass);
+    }
+
+    @Override
+    public void phantomize() {
+        getInitialized().phantomize();
+    }
+
+    @Nullable
+    @Override
+    public Element getElement() {
+        if (initialized == null) {
+            return element;
+        }
+
+        return getInitialized().getElement();
+    }
+
+    @Override
+    public void setElement(Element element) {
+        getInitialized().setElement(element);
+    }
+
+    @Override
+    public Element requireElement() throws IllegalStateException {
+        if (initialized == null) {
+            return element;
+        }
+
+        return getInitialized().requireElement();
+    }
+
+    @Override
+    public void removeParent() {
+        getInitialized().removeParent();
+    }
+
+    @Override
+    public XmlElement getParent() {
+        return getInitialized().getParent();
+    }
+
+    @Override
+    public void setParent(XmlElement parent) {
+        getInitialized().getParent();
+    }
+
+    @Override
+    public boolean isSubElement() {
+        return getInitialized().isSubElement();
+    }
+
+    @Override
+    public boolean isPersisted() {
+        if (initialized == null) {
+            return true;
+        }
+        return getInitialized().isPersisted();
+    }
+
+    @Override
+    public Context getContext() {
+        if (initialized == null) {
+            return context;
+        }
+        return getInitialized().getContext();
+    }
+
+    @Override
+    public String getTagName() {
+        return getInitialized().getTagName();
+    }
+
+    @Override
+    public List<XmlAttribute> getAttributes() {
+        return getInitialized().getAttributes();
+    }
+
+    @Override
+    public Map<String, XmlAttribute> getAttributeMap() {
+        return getInitialized().getAttributeMap();
+    }
+
+    @Override
+    public XmlAttribute getAttribute(String attributeName) {
+        return getInitialized().getAttribute(attributeName);
+    }
+
+    @Override
+    public void removeAttribute(String attributeName) {
+        getInitialized().removeAttribute(attributeName);
+    }
+
+    @Override
+    public void setAttribute(String attribute, Object value) {
+        getInitialized().setAttribute(attribute, value);
+    }
+
+    @Override
+    public boolean hasAttribute(String attributeName) {
+        return getInitialized().hasAttribute(attributeName);
+    }
+
+    @Override
+    public void addSubElement(XmlElement element) {
+        getInitialized().addSubElement(element);
+    }
+
+    @Override
+    public void addSubElements(List<XmlElement> elements) {
+        getInitialized().addSubElements(elements);
+    }
+
+    @Override
+    public void addSubElements(XmlElement... elements) {
+        getInitialized().addSubElements(elements);
+    }
+
+    @Override
+    public void removeSubElement(XmlElement element) {
+        getInitialized().removeSubElement(element);
+    }
+
+    @Override
+    public void removeSubElements(List<XmlElement> elements) {
+        getInitialized().removeSubElements(elements);
+    }
+
+    @Override
+    public void removeSubElements(XmlElement... elements) {
+        getInitialized().removeSubElements(elements);
+    }
+
+    @Override
+    public List<XmlElement> getSubElements() {
+        return getInitialized().getSubElements();
+    }
+
+    @Override
+    public List<XmlElement> getSubElementsRecursive() {
+        return getInitialized().getSubElementsRecursive();
+    }
+
+    @Override
+    public <E extends XmlElement> List<E> getSubElementsWithType(Class<E> type) {
+        return getInitialized().getSubElementsWithType(type);
+    }
+
+    @Nullable
+    @Override
+    public XmlElement getSubElement(String id) {
+        return getInitialized().getSubElement(id);
+    }
+
+    @Nullable
+    @Override
+    public <E extends XmlElement> E getSubElement(String id, Class<E> type) {
+        return getInitialized().getSubElement(id, type);
+    }
+
+    @Override
+    public XmlElement requireSubElement(String id) throws IllegalStateException {
+        return getInitialized().requireSubElement(id);
+    }
+
+    @Override
+    public <E extends XmlElement> E requireSubElement(String id, Class<E> type) throws IllegalStateException {
+        return getInitialized().requireSubElement(id, type);
+    }
+
+    @Override
+    public boolean hasSubElements() {
+        // before initialization we know this to be true because it is at least the parent of the child of this
+        // UninitializedParent but this method should remain accurate in case the subelement is removed after initialization
+        if (initialized == null) {
+            return true;
+        }
+        return getInitialized().hasSubElements();
+    }
+
+    @Override
+    public boolean hasSubElement(String id) {
+        if (initialized == null && Objects.equals(id, child.getId())) {
+            return true;
+        }
+        return getInitialized().hasSubElement(id);
+    }
+
+    @Override
+    public String getTextContent() {
+        return getInitialized().getTextContent();
+    }
+
+    @Override
+    public void setTextContent(String textContent) {
+        getInitialized().setTextContent(textContent);
+    }
+
+    @Override
+    public boolean hasTextContent() {
+        return getInitialized().hasTextContent();
+    }
+
+    @Nullable
+    @Override
+    public String getId() {
+        return getInitialized().getId();
+    }
+
+    @Override
+    @Deprecated
+    public boolean checkDuplicates(XmlElement elementToCheck) {
+        return getInitialized().checkDuplicates(elementToCheck);
+    }
+
+    @Override
+    public boolean matchesStructure(XmlElement elementToCompare) {
+        return getInitialized().matchesStructure(elementToCompare);
+    }
+
+    @Override
+    public void delete() {
+        getInitialized().delete();
+    }
+
+    @Override
+    public void addChange(ElementChangingEvent change) {
+        getInitialized().addChange(change);
+    }
+
+    @Override
+    public void removeChange(ElementChangingEvent change) {
+        getInitialized().removeChange(change);
+    }
+
+    @Override
+    public void applyChange(ElementChangingEvent change) throws UnsupportedOperationException, PersistException {
+        getInitialized().applyChange(change);
+    }
+
+    @Override
+    public void revertChange(ElementChangingEvent change) throws UnsupportedOperationException, PersistException {
+        getInitialized().revertChange(change);
+    }
+
+    @Override
+    public List<ElementChangingEvent> getChanges() {
+        return getInitialized().getChanges();
+    }
+
+    @Override
+    public boolean hasChanges() {
+        return getInitialized().hasChanges();
+    }
+
+    @Override
+    public boolean attributeChanged(String attributeName) {
+        return getInitialized().attributeChanged(attributeName);
+    }
+
+    @Override
+    public boolean textContentChanged() {
+        return getInitialized().textContentChanged();
+    }
+
+    @Override
+    public void lock() {
+        getInitialized().lock();
+    }
+
+    @Override
+    public void unlock() {
+        getInitialized().unlock();
+    }
+
+    @Override
+    public boolean isLocked() {
+        return getInitialized().isLocked();
+    }
+
+    @Override
+    public State getState() {
+        return getInitialized().getState();
+    }
+
+    @Override
+    public void setState(State state) {
+        getInitialized().setState(state);
+    }
+
+    @Override
+    public <E extends XmlElement> List<E> getInstancesOf(Class<E> c) {
+        return getInitialized().getInstancesOf(c);
+    }
+
+    @Override
+    public <E extends XmlElement> List<E> getInstancesOf(Class<E> c, Class<?>... ignoredSubClasses) {
+        return getInitialized().getInstancesOf(c, ignoredSubClasses);
+    }
+
+    @Override
+    public ResultStream<XmlElement> query(Predicate<XmlElement> condition) {
+        return getInitialized().query(condition);
+    }
+
+    @Override
+    public <E extends XmlElement> ResultStream<E> query(Predicate<XmlElement> condition, Class<E> type) {
+        return getInitialized().query(condition, type);
+    }
+}

--- a/src/main/java/net/robinfriedli/jxp/api/XmlAttribute.java
+++ b/src/main/java/net/robinfriedli/jxp/api/XmlAttribute.java
@@ -1,7 +1,7 @@
 package net.robinfriedli.jxp.api;
 
 import net.robinfriedli.jxp.events.AttributeChangingEvent;
-import net.robinfriedli.jxp.events.ElementChangingEvent;
+import net.robinfriedli.jxp.events.AttributeDeletedEvent;
 
 public class XmlAttribute {
 
@@ -35,7 +35,11 @@ public class XmlAttribute {
 
     public void setValue(Object value) {
         String stringValue = value instanceof String ? (String) value : StringConverter.reverse(value);
-        parentElement.addChange(ElementChangingEvent.attributeChange(new AttributeChangingEvent(this, stringValue)));
+        parentElement.addChange(new AttributeChangingEvent(this, stringValue));
+    }
+
+    public void remove() {
+        parentElement.addChange(new AttributeDeletedEvent(parentElement, this));
     }
 
     public <V> V getValue(Class<V> target) {
@@ -115,10 +119,19 @@ public class XmlAttribute {
         public void setValue(Object value) {
             if (definitiveAttribute == null) {
                 definitiveAttribute = new XmlAttribute(getParentElement(), getAttributeName());
-                getParentElement().addAttribute(definitiveAttribute);
+                getParentElement().getAttributeMap().put(getAttributeName(), definitiveAttribute);
             }
 
             definitiveAttribute.setValue(value);
+        }
+
+        @Override
+        public void remove() {
+            if (definitiveAttribute == null) {
+                throw new IllegalArgumentException(String.format("No such attribute '%s' on '%s'", getAttributeName(), getParentElement()));
+            }
+
+            definitiveAttribute.remove();
         }
 
         @Override

--- a/src/main/java/net/robinfriedli/jxp/api/XmlElement.java
+++ b/src/main/java/net/robinfriedli/jxp/api/XmlElement.java
@@ -1,13 +1,12 @@
 package net.robinfriedli.jxp.api;
 
 import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
-import net.robinfriedli.jxp.events.AttributeChangingEvent;
 import net.robinfriedli.jxp.events.ElementChangingEvent;
-import net.robinfriedli.jxp.events.ValueChangingEvent;
 import net.robinfriedli.jxp.exceptions.PersistException;
 import net.robinfriedli.jxp.persist.Context;
 import net.robinfriedli.jxp.queries.Conditions;
@@ -111,14 +110,19 @@ public interface XmlElement {
     Context getContext();
 
     /**
-     * @return Tag name for Class to be used in XML file
+     * @return Tag name for this xml element
      */
     String getTagName();
 
     /**
-     * @return XML attributes of XmlElement
+     * @return a new list instance containing all {@link XmlAttribute} instances on this XmlElement
      */
     List<XmlAttribute> getAttributes();
+
+    /**
+     * @return the actual map instance holding the {@link XmlAttribute} instances for this XmlElement
+     */
+    Map<String, XmlAttribute> getAttributeMap();
 
     /**
      * @param attributeName name of attribute
@@ -126,7 +130,14 @@ public interface XmlElement {
      */
     XmlAttribute getAttribute(String attributeName);
 
-    void addAttribute(XmlAttribute attribute);
+
+    /**
+     * Deletes the given attribute from this XmlElement. This action requires a Transaction for an XmlElement in a
+     * physical state.
+     *
+     * @param attributeName the name of the attribute to remove
+     */
+    void removeAttribute(String attributeName);
 
     /**
      * Set existing attribute to a different value or create a new one.
@@ -185,7 +196,7 @@ public interface XmlElement {
     void removeSubElements(XmlElement... elements);
 
     /**
-     * @return all SubElements
+     * @return all SubElements. This exposes the internal list directly.
      */
     List<XmlElement> getSubElements();
 
@@ -343,7 +354,7 @@ public interface XmlElement {
     void revertChange(ElementChangingEvent change) throws UnsupportedOperationException, PersistException;
 
     /**
-     * @return all {@link ElementChangingEvent} on this XmlElement
+     * @return all {@link ElementChangingEvent} on this XmlElement. This exposes the internal list directly.
      */
     List<ElementChangingEvent> getChanges();
 
@@ -351,41 +362,6 @@ public interface XmlElement {
      * @return true if this XmlElement has uncommitted {@link ElementChangingEvent}s
      */
     boolean hasChanges();
-
-    /**
-     * Returns the first {@link ElementChangingEvent} of this XmlElement that has not been persisted yet. Used to identify
-     * this XmlElement within the XML file. At least before {@link XmlElementShadow} was introduced.
-     *
-     * @return first {@link ElementChangingEvent}
-     */
-    @Deprecated
-    ElementChangingEvent getFirstChange();
-
-    /**
-     * Returns last uncommitted {@link ElementChangingEvent} of this XmlElement. Used to persist XmlElement changes.
-     *
-     * @return last {@link ElementChangingEvent}
-     */
-    @Deprecated
-    ElementChangingEvent getLastChange();
-
-    /**
-     * Get first change made to {@link XmlAttribute} with specified name since last commit
-     *
-     * @param attributeName name of attribute
-     * @return first change made to specified attribute since last commit
-     */
-    @Deprecated
-    AttributeChangingEvent getFirstAttributeChange(String attributeName);
-
-    /**
-     * Get last change made to {@link XmlAttribute} with specified name since last commit
-     *
-     * @param attributeName name of attribute
-     * @return last change made to specified attribute since last commit
-     */
-    @Deprecated
-    AttributeChangingEvent getLastAttributeChange(String attributeName);
 
     /**
      * Check if attribute with specified name has any uncommitted changes
@@ -396,22 +372,9 @@ public interface XmlElement {
     boolean attributeChanged(String attributeName);
 
     /**
-     * @return first uncommitted change made to the XmlElement's text content
-     */
-    @Deprecated
-    ValueChangingEvent<String> getFirstTextContentChange();
-
-    /**
      * @return true if this XmlElement's text content has uncommitted changes
      */
     boolean textContentChanged();
-
-    /**
-     * Clear all {@link ElementChangingEvent} on this XmlElement. Changes are cleared on commit but applied to the in
-     * memory XmlElement after adding.
-     */
-    @Deprecated
-    void clearChanges();
 
     /**
      * Prevents this XmlElement instance from being changed or deleted.
@@ -455,7 +418,7 @@ public interface XmlElement {
      * @param <E>               Type to return
      * @return All Elements that are an instance of specified Class but not specified subclasses
      */
-    <E extends XmlElement> List<E> getInstancesOf(Class<E> c, Class... ignoredSubClasses);
+    <E extends XmlElement> List<E> getInstancesOf(Class<E> c, Class<?>... ignoredSubClasses);
 
     /**
      * Checks all subElements for provided {@link Predicate}s and returns {@link QueryResult} with matching elements.

--- a/src/main/java/net/robinfriedli/jxp/events/AttributeChangingEvent.java
+++ b/src/main/java/net/robinfriedli/jxp/events/AttributeChangingEvent.java
@@ -2,7 +2,7 @@ package net.robinfriedli.jxp.events;
 
 import net.robinfriedli.jxp.api.XmlAttribute;
 
-public class AttributeChangingEvent extends HelperEvent {
+public class AttributeChangingEvent extends ElementChangingEvent {
 
     private final XmlAttribute attribute;
     private final String oldValue;
@@ -15,6 +15,11 @@ public class AttributeChangingEvent extends HelperEvent {
         this.newValue = newValue;
     }
 
+    @Override
+    public void doCommit() {
+        getSource().requireElement().setAttribute(attribute.getAttributeName(), newValue);
+    }
+
     public XmlAttribute getAttribute() {
         return attribute;
     }
@@ -25,5 +30,10 @@ public class AttributeChangingEvent extends HelperEvent {
 
     public String getNewValue() {
         return newValue;
+    }
+
+    @Override
+    protected void revertCommit() {
+        getSource().requireElement().setAttribute(attribute.getAttributeName(), oldValue);
     }
 }

--- a/src/main/java/net/robinfriedli/jxp/events/AttributeDeletedEvent.java
+++ b/src/main/java/net/robinfriedli/jxp/events/AttributeDeletedEvent.java
@@ -1,0 +1,28 @@
+package net.robinfriedli.jxp.events;
+
+import net.robinfriedli.jxp.api.XmlAttribute;
+import net.robinfriedli.jxp.api.XmlElement;
+
+public class AttributeDeletedEvent extends ElementChangingEvent {
+
+    private final XmlAttribute attribute;
+
+    public AttributeDeletedEvent(XmlElement source, XmlAttribute attribute) {
+        super(source);
+        this.attribute = attribute;
+    }
+
+    @Override
+    public void doCommit() {
+        getSource().requireElement().removeAttribute(attribute.getAttributeName());
+    }
+
+    public XmlAttribute getAttribute() {
+        return attribute;
+    }
+
+    @Override
+    protected void revertCommit() {
+        getSource().requireElement().setAttribute(attribute.getAttributeName(), attribute.getValue());
+    }
+}

--- a/src/main/java/net/robinfriedli/jxp/events/ElementChangingEvent.java
+++ b/src/main/java/net/robinfriedli/jxp/events/ElementChangingEvent.java
@@ -1,59 +1,40 @@
 package net.robinfriedli.jxp.events;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
-import com.google.common.collect.Lists;
 import net.robinfriedli.jxp.api.XmlElement;
 import net.robinfriedli.jxp.exceptions.PersistException;
-import org.w3c.dom.Element;
 
-public class ElementChangingEvent extends Event {
+public abstract class ElementChangingEvent extends Event {
 
-    @Nullable
-    private final List<AttributeChangingEvent> changedAttributes;
-
-    @Nullable
-    private final ValueChangingEvent<String> changedTextContent;
-
-    public ElementChangingEvent(AttributeChangingEvent changedAttribute) {
-        this(changedAttribute.getSource(), Lists.newArrayList(changedAttribute), null);
-    }
-
-    public ElementChangingEvent(XmlElement source, List<AttributeChangingEvent> changedAttributes) {
-        this(source, changedAttributes, null);
-    }
-
-    public ElementChangingEvent(ValueChangingEvent<String> changedTextContent) {
-        this(changedTextContent.getSource(), null, changedTextContent);
-    }
-
-    public ElementChangingEvent(XmlElement source,
-                                @Nullable List<AttributeChangingEvent> changedAttributes,
-                                @Nullable ValueChangingEvent<String> changedTextContent) {
+    public ElementChangingEvent(XmlElement source) {
         super(source);
-        this.changedAttributes = changedAttributes;
-        this.changedTextContent = changedTextContent;
-    }
-
-    public static ElementChangingEvent attributeChange(AttributeChangingEvent attributeChange) {
-        return new ElementChangingEvent(attributeChange);
-    }
-
-    public static ElementChangingEvent textContentChange(ValueChangingEvent<String> changedTextContent) {
-        return new ElementChangingEvent(changedTextContent);
     }
 
     @Nullable
-    public List<AttributeChangingEvent> getChangedAttributes() {
-        return changedAttributes;
+    public AttributeChangingEvent getAttributeChange() {
+        return unwrap(AttributeChangingEvent.class);
     }
 
     @Nullable
-    public ValueChangingEvent<String> getChangedTextContent() {
-        return changedTextContent;
+    public AttributeDeletedEvent getAttributeDeletion() {
+        return unwrap(AttributeDeletedEvent.class);
+    }
+
+    @Nullable
+    public TextContentChangingEvent getChangedTextContent() {
+        return unwrap(TextContentChangingEvent.class);
+    }
+
+    @Nullable
+    public <E extends ElementChangingEvent> E unwrap(Class<E> type) {
+        if (type.isInstance(this)) {
+            return type.cast(this);
+        }
+
+        return null;
     }
 
     @Override
@@ -67,83 +48,61 @@ public class ElementChangingEvent extends Event {
         }
     }
 
+    @Nullable
+    @Deprecated
+    public List<AttributeChangingEvent> getChangedAttributes() {
+        return null;
+    }
+
     @Override
     public void revert() {
         if (isApplied()) {
             getSource().revertChange(this);
             if (isCommitted()) {
-                Element element = getSource().requireElement();
-                List<AttributeChangingEvent> changedAttributes = getChangedAttributes();
-
-                if (changedAttributes != null && !changedAttributes.isEmpty()) {
-                    for (AttributeChangingEvent changedAttribute : changedAttributes) {
-                        element.setAttribute(changedAttribute.getAttribute().getAttributeName(), changedAttribute.getOldValue());
-                    }
-                }
-
-                if (textContentChanged()) {
-                    //noinspection ConstantConditions
-                    element.setTextContent(changedTextContent.getOldValue());
-                }
+                revertCommit();
             } else {
                 getSource().removeChange(this);
             }
         }
     }
 
+    protected abstract void doCommit();
+
+    protected abstract void revertCommit();
+
     @Override
     public void commit() {
-        XmlElement element = getSource();
-        Element elem = element.requireElement();
-        List<AttributeChangingEvent> attributeChanges = getChangedAttributes();
-
-        if (attributeChanges != null && !attributeChanges.isEmpty()) {
-            for (AttributeChangingEvent attributeChange : attributeChanges) {
-                elem.setAttribute(attributeChange.getAttribute().getAttributeName(), attributeChange.getNewValue());
-                attributeChange.setCommitted(true);
-            }
-        }
-        if (textContentChanged()) {
-            //noinspection ConstantConditions
-            elem.setTextContent(changedTextContent.getNewValue());
-        }
+        doCommit();
 
         setCommitted(true);
         getSource().removeChange(this);
     }
 
+    @Deprecated
     public boolean isEmpty() {
-        return (changedAttributes == null || changedAttributes.isEmpty())
-            && (changedTextContent == null);
+        return false;
     }
 
     public boolean attributeChanged(String attributeName) {
-        if (changedAttributes != null) {
-            return changedAttributes.stream().anyMatch(change -> change.getAttribute().getAttributeName().equals(attributeName));
+        AttributeChangingEvent attributeChange = getAttributeChange();
+        if (attributeChange != null) {
+            return attributeChange.getAttribute().getAttributeName().equals(attributeName);
         }
 
         return false;
     }
 
     public AttributeChangingEvent getAttributeChange(String attributeName) {
-        if (changedAttributes != null) {
-            List<AttributeChangingEvent> foundChanges = changedAttributes.stream()
-                .filter(change -> change.getAttribute().getAttributeName().equals(attributeName))
-                .collect(Collectors.toList());
-
-            if (foundChanges.size() == 1) {
-                return foundChanges.get(0);
-            } else if (foundChanges.size() > 1) {
-                // this should never happen since the event is generated when calling XmlAttribute#setValue
-                throw new IllegalStateException("Multiple changes recorded for attribute " + attributeName + " within the same event");
-            }
+        AttributeChangingEvent attributeChange = getAttributeChange();
+        if (attributeChange != null && attributeChange.getAttribute().getAttributeName().equals(attributeName)) {
+            return attributeChange;
         }
 
         return null;
     }
 
     public boolean textContentChanged() {
-        return changedTextContent != null;
+        return getChangedTextContent() != null;
     }
 
 }

--- a/src/main/java/net/robinfriedli/jxp/events/TextContentChangingEvent.java
+++ b/src/main/java/net/robinfriedli/jxp/events/TextContentChangingEvent.java
@@ -1,0 +1,34 @@
+package net.robinfriedli.jxp.events;
+
+import net.robinfriedli.jxp.api.XmlElement;
+
+public class TextContentChangingEvent extends ElementChangingEvent {
+
+    private final String oldValue;
+    private final String newValue;
+
+    public TextContentChangingEvent(XmlElement source, String oldValue, String newValue) {
+        super(source);
+        this.oldValue = oldValue;
+        this.newValue = newValue;
+    }
+
+    @Override
+    public void doCommit() {
+        getSource().requireElement().setTextContent(newValue);
+    }
+
+    public String getOldValue() {
+        return oldValue;
+    }
+
+    public String getNewValue() {
+        return newValue;
+    }
+
+    @Override
+    protected void revertCommit() {
+        getSource().requireElement().setTextContent(oldValue);
+    }
+
+}

--- a/src/main/java/net/robinfriedli/jxp/events/VirtualEvent.java
+++ b/src/main/java/net/robinfriedli/jxp/events/VirtualEvent.java
@@ -49,7 +49,7 @@ public class VirtualEvent extends Event {
                     if (transaction != null) {
                         transaction.queueTask(queuedTask);
                     } else {
-                        queuedTask.run();
+                        queuedTask.runLoggingErrors();
                     }
                 }
             }

--- a/src/main/java/net/robinfriedli/jxp/exec/AbstractTransactionalMode.java
+++ b/src/main/java/net/robinfriedli/jxp/exec/AbstractTransactionalMode.java
@@ -31,11 +31,7 @@ public abstract class AbstractTransactionalMode extends AbstractDelegatingModeWr
             newTransaction = getTransaction();
             oldTransaction = null;
             if (activeTransaction != null) {
-                if (activeTransaction.isActive()) {
-                    switchTx();
-                } else {
-                    switchTx();
-                }
+                switchTx();
             } else {
                 openTx();
             }
@@ -64,7 +60,7 @@ public abstract class AbstractTransactionalMode extends AbstractDelegatingModeWr
                     if (failed && t.isCancelOnFailure()) {
                         t.cancel(false);
                     } else {
-                        t.run();
+                        t.runLoggingErrors();
                     }
                 });
             }

--- a/src/main/java/net/robinfriedli/jxp/exec/MutexSync.java
+++ b/src/main/java/net/robinfriedli/jxp/exec/MutexSync.java
@@ -1,0 +1,59 @@
+package net.robinfriedli.jxp.exec;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+/**
+ * Mutex utility that synchronises tasks with a mutex mapped to a value of type T. This utilizes a {@link ReferenceCountedMutex}
+ * to make sure mutexes don't stay in the map indefinitely and leak memory while ensuring they are not cleared up too
+ * early in a more than 2 threads scenario. E.g. without reference counting the following would happen: thread A has
+ * created a mutex and starts executing its task, meanwhile thread B starts, finds the mutex and waits for its lock.
+ * Then thread A finishes and removes the mutex from the map and thread B starts executing. At the same time thread C starts
+ * and because thread A has already removed the mutex from the map it can't find it anymore and immediately starts executing
+ * its task despite thread B still being active. See the comments in code for an illustration.
+ *
+ * @param <T> type of key the mutexes are mapped to.
+ */
+public class MutexSync<T> {
+
+    public static final MutexSync<String> GLOBAL_CONTEXT_SYNC = new MutexSync<>();
+
+    private final Map<T, ReferenceCountedMutex<T>> mutexMap = new ConcurrentHashMap<>();
+
+    @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")
+    public <E> E evaluateChecked(T key, Callable<E> toRun) throws Exception {
+        ReferenceCountedMutex<T> mutex = mutexMap.computeIfAbsent(key, k -> new ReferenceCountedMutex<>(k, mutexMap));
+
+        mutex.incrementRc();
+        // -- thread C is here
+        synchronized (mutex) {
+            try {
+                return toRun.call(); // - thread B is still here
+            } finally {
+                mutex.decrementRc();
+                // -- thread A is here (without reference counting it would have removed the mutex)
+            }
+        }
+    }
+
+    public <E> E evaluate(T key, Supplier<E> toRun) {
+        try {
+            return evaluateChecked(key, toRun::get);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            // suppliers do not throw checked exceptions
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void run(T key, Runnable toRun) {
+        evaluate(key, () -> {
+            toRun.run();
+            return null;
+        });
+    }
+
+}

--- a/src/main/java/net/robinfriedli/jxp/exec/QueuedTask.java
+++ b/src/main/java/net/robinfriedli/jxp/exec/QueuedTask.java
@@ -6,35 +6,28 @@ import java.util.concurrent.FutureTask;
 
 import org.slf4j.Logger;
 
-import net.robinfriedli.jxp.exec.modes.ListenersMutedMode;
 import net.robinfriedli.jxp.persist.Context;
 
+/**
+ * Task that encapsulates transactions happening sometime in the future. this may and often is used to queue tasks after
+ * the current transaction to then run them in the same thread. For that reason those tasks do not run synchronised as
+ * their parent task already does. Else this can be used to execute tasks in a separate thread, in this case the sync
+ * mode should be applied, see {@link Context#futureInvoke(boolean, boolean, Invoker.Mode, Callable)}.
+ *
+ * @param <E> the return type of the task.
+ */
 public class QueuedTask<E> extends FutureTask<E> {
 
     private final boolean cancelOnFailure;
     private final Logger logger;
 
-    public QueuedTask(Context context, boolean commit, boolean instantApply, boolean cancelOnFailure, boolean triggerListeners, Callable<E> callable, Logger logger) {
-        super(() -> {
-            Invoker.Mode mode = Invoker.Mode.create();
-
-            if (!triggerListeners) {
-                mode.with(new ListenersMutedMode(context.getBackend()));
-            }
-
-            AbstractTransactionalMode transactionalMode = AbstractTransactionalMode.Builder.create()
-                .setInstantApply(instantApply)
-                .shouldCommit(commit)
-                .build(context);
-            mode.with(transactionalMode);
-            return context.invoke(mode, callable);
-        });
+    public QueuedTask(Context context, boolean cancelOnFailure, Invoker.Mode mode, Callable<E> callable, Logger logger) {
+        super(() -> context.invoke(mode, callable));
         this.cancelOnFailure = cancelOnFailure;
         this.logger = logger;
     }
 
-    @Override
-    public void run() {
+    public void runLoggingErrors() {
         super.run();
         try {
             get();

--- a/src/main/java/net/robinfriedli/jxp/exec/ReferenceCountedMutex.java
+++ b/src/main/java/net/robinfriedli/jxp/exec/ReferenceCountedMutex.java
@@ -1,0 +1,39 @@
+package net.robinfriedli.jxp.exec;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Type used for mutexes contained in a map that automatically removes itself from the map when there is no thread
+ * using it anymore.
+ */
+public class ReferenceCountedMutex<T> {
+
+    private final T key;
+    private final Map<T, ReferenceCountedMutex<T>> containingMap;
+    private AtomicInteger rc = new AtomicInteger(0);
+
+    public ReferenceCountedMutex(T key, Map<T, ReferenceCountedMutex<T>> containingMap) {
+        this.key = key;
+        this.containingMap = containingMap;
+    }
+
+    public void incrementRc() {
+        rc.incrementAndGet();
+    }
+
+    /**
+     * @return true if the mutex removed itself from the map
+     */
+    public synchronized boolean decrementRc() {
+        int currentRc = rc.decrementAndGet();
+
+        if (currentRc < 1) {
+            return containingMap.remove(key) != null;
+        }
+
+        return false;
+    }
+
+
+}

--- a/src/main/java/net/robinfriedli/jxp/exec/modes/MutexSyncMode.java
+++ b/src/main/java/net/robinfriedli/jxp/exec/modes/MutexSyncMode.java
@@ -1,0 +1,21 @@
+package net.robinfriedli.jxp.exec.modes;
+
+import java.util.concurrent.Callable;
+
+import net.robinfriedli.jxp.exec.AbstractDelegatingModeWrapper;
+import net.robinfriedli.jxp.exec.MutexSync;
+
+public class MutexSyncMode extends AbstractDelegatingModeWrapper {
+
+    private final String mutexKey;
+
+    public MutexSyncMode(String mutexKey) {
+        this.mutexKey = mutexKey;
+    }
+
+    @Override
+    public <E> Callable<E> wrap(Callable<E> callable) {
+        return () -> MutexSync.GLOBAL_CONTEXT_SYNC.evaluateChecked(mutexKey, callable);
+    }
+
+}

--- a/src/main/java/net/robinfriedli/jxp/persist/BindableLazyContext.java
+++ b/src/main/java/net/robinfriedli/jxp/persist/BindableLazyContext.java
@@ -1,0 +1,28 @@
+package net.robinfriedli.jxp.persist;
+
+import java.io.File;
+
+import org.slf4j.Logger;
+
+import net.robinfriedli.jxp.api.JxpBackend;
+import org.w3c.dom.Document;
+
+public class BindableLazyContext<E> extends LazyContext implements Context.BindableContext<E> {
+
+    private final E boundObject;
+
+    public BindableLazyContext(JxpBackend backend, Document document, E boundObject, Logger logger) {
+        super(backend, document, logger);
+        this.boundObject = boundObject;
+    }
+
+    public BindableLazyContext(JxpBackend backend, File file, E boundObject, Logger logger) {
+        super(backend, file, logger);
+        this.boundObject = boundObject;
+    }
+
+    @Override
+    public E getBindingObject() {
+        return boundObject;
+    }
+}

--- a/src/main/java/net/robinfriedli/jxp/persist/DefaultPersistenceManager.java
+++ b/src/main/java/net/robinfriedli/jxp/persist/DefaultPersistenceManager.java
@@ -2,29 +2,20 @@ package net.robinfriedli.jxp.persist;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.List;
-import java.util.Map;
 
 import javax.annotation.Nullable;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 
 import com.google.common.collect.Lists;
-import net.robinfriedli.jxp.api.BaseXmlElement;
 import net.robinfriedli.jxp.api.StaticXmlElementFactory;
 import net.robinfriedli.jxp.api.XmlAttribute;
 import net.robinfriedli.jxp.api.XmlElement;
 import net.robinfriedli.jxp.events.AttributeChangingEvent;
 import net.robinfriedli.jxp.events.ElementChangingEvent;
-import net.robinfriedli.jxp.events.ValueChangingEvent;
+import net.robinfriedli.jxp.events.TextContentChangingEvent;
 import net.robinfriedli.jxp.exceptions.CommitException;
 import net.robinfriedli.jxp.exceptions.PersistException;
 import org.w3c.dom.Document;
@@ -55,36 +46,7 @@ public class DefaultPersistenceManager {
 
     @Deprecated
     public XmlElement instantiateXmlElement(Element element, Context context) {
-        Map<String, Class<? extends XmlElement>> instantiationContributions = StaticXmlElementFactory.INSTANTIATION_CONTRIBUTIONS;
-        List<Element> subElements = getChildren(element);
-        List<XmlElement> instantiatedSubElems = Lists.newArrayList();
-
-        for (Element subElement : subElements) {
-            instantiatedSubElems.add(instantiateXmlElement(subElement, context));
-        }
-
-        Class<? extends XmlElement> xmlClass = instantiationContributions.get(element.getTagName());
-        if (xmlClass != null) {
-            try {
-                if (subElements.isEmpty()) {
-                    Constructor<? extends XmlElement> constructor = xmlClass.getConstructor(Element.class, Context.class);
-                    return constructor.newInstance(element, context);
-                } else {
-                    Constructor<? extends XmlElement> constructor = xmlClass.getConstructor(Element.class, List.class, Context.class);
-                    return constructor.newInstance(element, instantiatedSubElems, context);
-                }
-            } catch (NoSuchMethodException e) {
-                throw new PersistException("Your class " + xmlClass + " does not have the appropriate Constructor", e);
-            } catch (IllegalAccessException e) {
-                throw new PersistException("Cannot access constructor of class " + xmlClass, e);
-            } catch (InstantiationException e) {
-                throw new PersistException("Cannot instantiate class " + xmlClass, e);
-            } catch (InvocationTargetException e) {
-                throw new PersistException("Exception while invoking constructor of " + xmlClass, e);
-            }
-        } else {
-            return new BaseXmlElement(element, instantiatedSubElems, context);
-        }
+        return StaticXmlElementFactory.instantiatePersistentXmlElement(element, context);
     }
 
     @Deprecated
@@ -111,29 +73,14 @@ public class DefaultPersistenceManager {
     }
 
     @Deprecated
-    public void setTextContent(ValueChangingEvent<String> changedTextContent) throws CommitException {
+    public void setTextContent(TextContentChangingEvent changedTextContent) throws CommitException {
         Element element = requireElement(changedTextContent.getSource());
         element.setTextContent(changedTextContent.getNewValue());
     }
 
     @Deprecated
     public void writeToFile(Context context) throws CommitException {
-        if (!context.isPersistent()) {
-            throw new CommitException("Context is not persistent. Cannot write to file");
-        }
-
-        Document doc = context.getDocument();
-        try {
-            TransformerFactory transformerFactory = TransformerFactory.newInstance();
-            Transformer transformer = transformerFactory.newTransformer();
-            DOMSource source = new DOMSource(doc);
-            @SuppressWarnings("ConstantConditions")
-            StreamResult result = new StreamResult(context.getFile());
-
-            transformer.transform(source, result);
-        } catch (TransformerException e) {
-            throw new CommitException("Exception while writing to file", e);
-        }
+        StaticXmlParser.writeToFile(context);
     }
 
     @Deprecated
@@ -184,7 +131,7 @@ public class DefaultPersistenceManager {
     public void castElement(XmlElement target, XmlElement source) {
         if (target.matchesStructure(source)) {
             List<AttributeChangingEvent> changedAttributes = Lists.newArrayList();
-            ValueChangingEvent<String> changedTextContent = null;
+            TextContentChangingEvent changedTextContent = null;
 
             for (XmlAttribute attribute : source.getAttributes()) {
                 XmlAttribute existingAttribute = target.getAttribute(attribute.getAttributeName());
@@ -194,7 +141,7 @@ public class DefaultPersistenceManager {
             }
 
             if (!target.getTextContent().equals(source.getTextContent())) {
-                changedTextContent = new ValueChangingEvent<>(target, target.getTextContent(), source.getTextContent());
+                changedTextContent = new TextContentChangingEvent(target, target.getTextContent(), source.getTextContent());
             }
 
             List<XmlElement> addedSubElements = Lists.newArrayList();
@@ -215,10 +162,11 @@ public class DefaultPersistenceManager {
                 }
             }
 
-            ElementChangingEvent elementChangingEvent = new ElementChangingEvent(target, changedAttributes, changedTextContent);
-
-            if (!elementChangingEvent.isEmpty()) {
-                target.addChange(elementChangingEvent);
+            for (AttributeChangingEvent changedAttribute : changedAttributes) {
+                target.addChange(changedAttribute);
+            }
+            if (changedTextContent != null) {
+                target.addChange(changedTextContent);
             }
             if (!addedSubElements.isEmpty()) {
                 target.addSubElements(addedSubElements);

--- a/src/main/java/net/robinfriedli/jxp/persist/LazyContext.java
+++ b/src/main/java/net/robinfriedli/jxp/persist/LazyContext.java
@@ -2,16 +2,19 @@ package net.robinfriedli.jxp.persist;
 
 import java.io.File;
 import java.util.List;
+import java.util.Objects;
 
 import org.slf4j.Logger;
 
 import com.google.common.collect.Lists;
 import net.robinfriedli.jxp.api.JxpBackend;
 import net.robinfriedli.jxp.api.StaticXmlElementFactory;
+import net.robinfriedli.jxp.api.UninitializedParent;
 import net.robinfriedli.jxp.api.XmlElement;
 import net.robinfriedli.jxp.queries.xpath.XQueryBuilder;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 
 /**
  * Context implementation with focus on low memory usage. This context type only stores XmlElements in state CONCEPTION
@@ -70,7 +73,13 @@ public class LazyContext extends AbstractContext {
         List<XmlElement> elementInstances = Lists.newArrayList();
 
         for (Element docElement : results) {
-            elementInstances.add(StaticXmlElementFactory.instantiatePersistentXmlElement(docElement, this));
+            XmlElement xmlElement = StaticXmlElementFactory.instantiatePersistentXmlElement(docElement, this);
+            Node parentNode = docElement.getParentNode();
+            if (parentNode instanceof Element && !Objects.equals(parentNode, parentNode.getOwnerDocument().getDocumentElement())) {
+                xmlElement.setParent(new UninitializedParent(this, (Element) parentNode, xmlElement));
+            }
+
+            elementInstances.add(xmlElement);
         }
 
         return elementInstances;

--- a/src/main/java/net/robinfriedli/jxp/persist/StaticXmlParser.java
+++ b/src/main/java/net/robinfriedli/jxp/persist/StaticXmlParser.java
@@ -2,6 +2,7 @@ package net.robinfriedli.jxp.persist;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -17,9 +18,9 @@ import net.robinfriedli.jxp.exceptions.PersistException;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
-class StaticXmlParser {
+public class StaticXmlParser {
 
-    static void writeToFile(Context context) throws CommitException {
+    public static void writeToFile(Context context) throws CommitException {
         if (!context.isPersistent()) {
             throw new CommitException("Context is not persistent. Cannot write to file");
         }
@@ -38,7 +39,18 @@ class StaticXmlParser {
         }
     }
 
-    static Document parseDocument(File xml) {
+    public static Document parseDocument(File xml) {
+        try {
+            DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+            return dBuilder.parse(xml);
+        } catch (IOException | SAXException | ParserConfigurationException e) {
+            throw new PersistException("Exception while parsing document", e);
+        }
+    }
+
+
+    public static Document parseDocument(InputStream xml) {
         try {
             DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
             DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();

--- a/src/main/java/net/robinfriedli/jxp/queries/Conditions.java
+++ b/src/main/java/net/robinfriedli/jxp/queries/Conditions.java
@@ -63,4 +63,8 @@ public final class Conditions {
         return and(XmlElement::hasSubElements, xmlElement -> xmlElement.getSubElements().stream().allMatch(subPredicate));
     }
 
+    public static Predicate<XmlElement> parentMatches(Predicate<XmlElement> parentPredicate) {
+        return and(XmlElement::isSubElement, xmlElement -> parentPredicate.test(xmlElement.getParent()));
+    }
+
 }

--- a/src/main/java/net/robinfriedli/jxp/queries/Order.java
+++ b/src/main/java/net/robinfriedli/jxp/queries/Order.java
@@ -5,23 +5,26 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
+import net.robinfriedli.jxp.api.StringConverter;
 import net.robinfriedli.jxp.api.XmlElement;
 
 
-public class Order {
+public class Order<E extends Comparable<E>> {
 
     @Nullable
     private final String attribute;
     private final Direction direction;
     private final Source source;
+    private final Class<E> attributeType;
 
-    public Order(Direction direction, Source source) {
-        this(null, direction, source);
+    public Order(Direction direction, Source source, Class<E> attributeType) {
+        this(null, direction, source, attributeType);
     }
 
-    public Order(@Nullable String attribute, Direction direction, Source source) {
+    public Order(@Nullable String attribute, Direction direction, Source source, Class<E> attributeType) {
         this.source = source;
         this.direction = direction;
+        this.attributeType = attributeType;
         if (source == Source.ATTRIBUTE) {
             if (attribute != null) {
                 this.attribute = attribute;
@@ -35,23 +38,39 @@ public class Order {
         }
     }
 
-    public static Order attribute(String name, Direction direction) {
-        return new Order(name, direction, Source.ATTRIBUTE);
+    public static Order<String> attribute(String name, Direction direction) {
+        return new Order<>(name, direction, Source.ATTRIBUTE, String.class);
     }
 
-    public static Order attribute(String name) {
-        return new Order(name, Direction.ASCENDING, Source.ATTRIBUTE);
+    public static Order<String> attribute(String name) {
+        return new Order<>(name, Direction.ASCENDING, Source.ATTRIBUTE, String.class);
     }
 
-    public static Order textContent(Direction direction) {
-        return new Order(direction, Source.TEXT_CONTENT);
+    public static Order<String> textContent(Direction direction) {
+        return new Order<>(direction, Source.TEXT_CONTENT, String.class);
     }
 
-    public static Order textContent() {
-        return new Order(Direction.ASCENDING, Source.TEXT_CONTENT);
+    public static Order<String> textContent() {
+        return new Order<>(Direction.ASCENDING, Source.TEXT_CONTENT, String.class);
     }
 
-    public <E extends XmlElement> Stream<E> applyOrder(Stream<E> resultStream) {
+    public static <E extends Comparable<E>> Order<E> attribute(String name, Direction direction, Class<E> attributeType) {
+        return new Order<>(name, direction, Source.ATTRIBUTE, attributeType);
+    }
+
+    public static <E extends Comparable<E>> Order<E> attribute(String name, Class<E> attributeType) {
+        return new Order<>(name, Direction.ASCENDING, Source.ATTRIBUTE, attributeType);
+    }
+
+    public static <E extends Comparable<E>> Order<E> textContent(Direction direction, Class<E> attributeType) {
+        return new Order<>(direction, Source.TEXT_CONTENT, attributeType);
+    }
+
+    public static <E extends Comparable<E>> Order<E> textContent(Class<E> attributeType) {
+        return new Order<>(Direction.ASCENDING, Source.TEXT_CONTENT, attributeType);
+    }
+
+    public <O extends XmlElement> Stream<O> applyOrder(Stream<O> resultStream) {
         Comparator<XmlElement> comparator = getComparator();
         return resultStream.sorted(comparator);
     }
@@ -59,15 +78,9 @@ public class Order {
     public Comparator<XmlElement> getComparator() {
         Comparator<XmlElement> comparator;
         if (source == Source.ATTRIBUTE) {
-            comparator = Comparator.comparing(v -> {
-                if (v.hasAttribute(attribute)) {
-                    return v.getAttribute(attribute).getValue();
-                } else {
-                    return "";
-                }
-            });
+            comparator = Comparator.comparing(v -> v.getAttribute(attribute).getValue(attributeType));
         } else {
-            comparator = Comparator.comparing(XmlElement::getTextContent);
+            comparator = Comparator.comparing(v -> StringConverter.convert(v.getTextContent(), attributeType));
         }
 
         if (direction == Direction.DESCENDING) {

--- a/src/main/java/net/robinfriedli/jxp/queries/Query.java
+++ b/src/main/java/net/robinfriedli/jxp/queries/Query.java
@@ -5,12 +5,11 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import net.robinfriedli.jxp.api.XmlElement;
-import net.robinfriedli.jxp.exceptions.QueryException;
 
 public class Query {
 
     private final Predicate<XmlElement> expression;
-    private Order order;
+    private Order<?> order;
 
     public Query(Predicate<XmlElement> expression) {
         this.expression = expression;
@@ -20,30 +19,21 @@ public class Query {
         return new Query(expression);
     }
 
-    private static QueryException getCastException(Class type, Throwable cause) {
-        return new QueryException("Some found elements could not be converted to " + type + ". " +
-            "Consider expanding your query with the Conditions#instanceOf condition.", cause);
-    }
-
     public ResultStream<XmlElement> execute(Collection<XmlElement> elements) {
         return execute(elements, XmlElement.class);
     }
 
     public <E extends XmlElement> ResultStream<E> execute(Collection<XmlElement> elements, Class<E> type) {
-        try {
-            Stream<E> found = elements.stream().filter(expression).map(type::cast);
+        Stream<E> found = elements.stream().filter(expression).map(type::cast);
 
-            if (order != null) {
-                found = order.applyOrder(found);
-            }
-
-            return new ResultStream<>(found);
-        } catch (ClassCastException e) {
-            throw getCastException(type, e);
+        if (order != null) {
+            found = order.applyOrder(found);
         }
+
+        return new ResultStream<>(found);
     }
 
-    public Query order(Order order) {
+    public Query order(Order<?> order) {
         this.order = order;
         return this;
     }

--- a/src/test/java/net/robinfriedli/jxp/AbstractTest.java
+++ b/src/test/java/net/robinfriedli/jxp/AbstractTest.java
@@ -1,0 +1,102 @@
+package net.robinfriedli.jxp;
+
+import java.io.InputStream;
+import java.util.function.Consumer;
+
+import org.testng.annotations.*;
+
+import net.robinfriedli.jxp.api.JxpBackend;
+import net.robinfriedli.jxp.persist.Context;
+
+public abstract class AbstractTest {
+
+    protected JxpBackend jxp;
+
+    @BeforeClass
+    public void initializeJxp() {
+        jxp = setupJxp();
+    }
+
+    protected InputStream getTestResource(String resourceName) {
+        InputStream inputStream = getClass().getResourceAsStream(resourceName);
+
+        if (inputStream == null) {
+            throw new IllegalArgumentException("No such resource " + resourceName);
+        }
+
+        return inputStream;
+    }
+
+    protected void expectException(Class<? extends Throwable> exceptionType, Runnable runnable) {
+        Throwable caught = null;
+        try {
+            runnable.run();
+        } catch (Throwable e) {
+            caught = e;
+        }
+
+        if (caught == null) {
+            throw new IllegalStateException("Expected a Throwable of type " + exceptionType + " to be thrown");
+        } else if (!exceptionType.isAssignableFrom(caught.getClass())) {
+            throw new IllegalStateException(String.format("Expected exception of type: %s; got: %s", exceptionType, caught.getClass()));
+        }
+    }
+
+    /**
+     * Opens a Context for the provided XML file, creates a copy, performs the given action with the copied context and
+     * optionally persists the copied context to an XmlFile in the resources/output directory
+     *
+     * @param persistAfter whether or not to write the new document to a file
+     * @param resourceName the name of the source xml file
+     * @param action       the task to perform
+     */
+    protected void doWithCopiedContext(boolean persistAfter, String resourceName, Consumer<Context> action) {
+        doWithCopiedContextInternal(persistAfter, resourceName, action);
+    }
+
+    protected void doWithCopiedContext(String resourceName, Consumer<Context> action) {
+        doWithCopiedContextInternal(true, resourceName, action);
+    }
+
+    /**
+     * Exists so that both non private doWithCopiedContext have the same amount of stack frames after bein called by the
+     * test.
+     */
+    private void doWithCopiedContextInternal(boolean persistAfter, String resourceName, Consumer<Context> action) {
+        Context existingContext = jxp.createContext(getTestResource(resourceName));
+        Context context = existingContext.copy();
+        action.accept(context);
+
+        if (persistAfter) {
+            int index = 3;
+            StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+            String methodName;
+            if (stackTrace.length > index) {
+                methodName = "@" + stackTrace[index].getMethodName();
+            } else {
+                methodName = "";
+            }
+            context.persist(String.format("src/test/resources/output/%s%s%s.xml", getClass().getSimpleName(), methodName, System.currentTimeMillis()));
+        }
+    }
+
+    protected abstract JxpBackend setupJxp();
+
+    protected static class ErrorReportingExceptionHandler implements Thread.UncaughtExceptionHandler {
+
+        private Throwable error;
+
+        public ErrorReportingExceptionHandler() {
+        }
+
+        @Override
+        public void uncaughtException(Thread t, Throwable e) {
+            error = e;
+        }
+
+        public Throwable getError() {
+            return error;
+        }
+    }
+
+}

--- a/src/test/java/net/robinfriedli/jxp/api/ConcurrentAccessTest.java
+++ b/src/test/java/net/robinfriedli/jxp/api/ConcurrentAccessTest.java
@@ -1,0 +1,128 @@
+package net.robinfriedli.jxp.api;
+
+import org.testng.annotations.*;
+
+import net.robinfriedli.jxp.AbstractTest;
+import net.robinfriedli.jxp.persist.Context;
+
+public class ConcurrentAccessTest extends AbstractTest {
+
+    @Override
+    protected JxpBackend setupJxp() {
+        return new JxpBuilder().build();
+    }
+
+    @AfterMethod
+    public void cleanup() {
+        jxp.clearContexts();
+    }
+
+    @Test
+    public void testConcurrentCheckForContext() throws Throwable {
+        Context context = jxp.getContext("src/test/resources/countries.xml");
+
+        for (int i = 0; i < 5000; i++) {
+            Context copy = context.copy();
+            jxp.attachContext(copy);
+        }
+
+        Context.BindableContext<String> c2 = jxp.createBoundContext("src/test/resources/fullcountries.xml", "c2");
+        Context.BindableContext<String> c3 = jxp.createBoundContext("src/test/resources/fullcountries-raw.xml", "c3");
+
+        jxp.attachContext(c2);
+        jxp.attachContext(c3);
+
+        Runnable runnable = () -> {
+            for (int i = 0; i < 5000; i++) {
+                jxp.getContext("src/test/resources/countries.xml");
+                jxp.getContext("src/test/resources/fullcountries.xml");
+                jxp.getContext("src/test/resources/fullcountries-raw.xml");
+
+                jxp.getExistingContext("src/test/resources/countries.xml");
+                jxp.getExistingContext("src/test/resources/fullcountries.xml");
+                jxp.getExistingContext("src/test/resources/fullcountries-raw.xml");
+
+                jxp.getBoundContext("c1");
+                jxp.getBoundContext("c2");
+                jxp.getBoundContext("c3");
+
+                jxp.hasBoundContext("c4");
+                jxp.hasBoundContext("c1");
+                jxp.hasContext("foo");
+                jxp.hasContext(context.getDocument());
+            }
+        };
+
+        Thread t1 = new Thread(runnable);
+        Thread t2 = new Thread(runnable);
+        Thread t3 = new Thread(runnable);
+        Thread t4 = new Thread(() -> {
+            for (int i = 0; i < 5000; i++) {
+                Context copy = context.copy();
+                jxp.attachContext(copy);
+            }
+        });
+
+        ErrorReportingExceptionHandler exceptionHandler = new ErrorReportingExceptionHandler();
+
+        t1.setUncaughtExceptionHandler(exceptionHandler);
+        t2.setUncaughtExceptionHandler(exceptionHandler);
+        t3.setUncaughtExceptionHandler(exceptionHandler);
+        t4.setUncaughtExceptionHandler(exceptionHandler);
+
+        t1.start();
+        t2.start();
+        t3.start();
+        t4.start();
+
+        t1.join();
+        t2.join();
+        t3.join();
+        t4.join();
+
+        Throwable error = exceptionHandler.getError();
+        if (error != null) {
+            throw error;
+        }
+    }
+
+    @Test
+    public void testConcurrentContextCreation() throws Throwable {
+        Runnable runnable = () -> {
+            for (int i = 0; i < 5000; i++) {
+                jxp.getContext("src/test/resources/countries.xml");
+                jxp.getContext("src/test/resources/fullcountries.xml");
+                if (i < 20) {
+                    Context context = jxp.createContext(getTestResource("/fullcountries-raw.xml"));
+                    jxp.attachContext(context);
+                }
+            }
+        };
+
+        Thread t1 = new Thread(runnable);
+        Thread t2 = new Thread(runnable);
+        Thread t3 = new Thread(runnable);
+
+        ErrorReportingExceptionHandler exceptionHandler = new ErrorReportingExceptionHandler();
+        t1.setUncaughtExceptionHandler(exceptionHandler);
+        t2.setUncaughtExceptionHandler(exceptionHandler);
+        t3.setUncaughtExceptionHandler(exceptionHandler);
+
+        t1.start();
+        t2.start();
+        t3.start();
+
+        t1.join();
+        t2.join();
+        t3.join();
+
+        Throwable error = exceptionHandler.getError();
+        if (error != null) {
+            throw error;
+        }
+
+        jxp.requireExistingContext("src/test/resources/countries.xml");
+        jxp.requireExistingContext("src/test/resources/fullcountries.xml");
+    }
+
+}

--- a/src/test/java/net/robinfriedli/jxp/api/ContextCreationTest.java
+++ b/src/test/java/net/robinfriedli/jxp/api/ContextCreationTest.java
@@ -1,0 +1,97 @@
+package net.robinfriedli.jxp.api;
+
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.testng.annotations.*;
+
+import net.robinfriedli.jxp.AbstractTest;
+import net.robinfriedli.jxp.entities.TestElem;
+import net.robinfriedli.jxp.persist.Context;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import static org.testng.Assert.*;
+
+public class ContextCreationTest extends AbstractTest {
+
+    @Test // creating a context from a file or inputstream is already thoroughly covered by other tests
+    public void testCreateContextFromDomDocument() throws ParserConfigurationException {
+        Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element rootElem = document.createElement("tests");
+        rootElem.setAttribute("xmlns", "testSpace");
+        document.appendChild(rootElem);
+
+        Context context = jxp.getContext(document);
+
+        TestElem test1 = new TestElem("test1", "test");
+        TestElem test11 = new TestElem("test11", "test");
+        TestElem test12 = new TestElem("test12", "test");
+        TestElem test111 = new TestElem("test111", "test");
+        TestElem test112 = new TestElem("test112", "test");
+        TestElem test113 = new TestElem("test113", "test");
+        TestElem test121 = new TestElem("test121", "test");
+        TestElem test122 = new TestElem("test122", "test");
+        TestElem test123 = new TestElem("test123", "test");
+        TestElem test2 = new TestElem("test2", "test");
+        TestElem test21 = new TestElem("test21", "test");
+        TestElem test22 = new TestElem("test22", "test");
+        TestElem test211 = new TestElem("test211", "test");
+        TestElem test212 = new TestElem("test212", "test");
+        TestElem test213 = new TestElem("test213", "test");
+        TestElem test221 = new TestElem("test221", "test");
+        TestElem test222 = new TestElem("test222", "test");
+        TestElem test223 = new TestElem("test223", "test");
+
+        context.invoke(() -> {
+            test1.addSubElements(test11, test12);
+            test11.addSubElements(test111, test112, test113);
+            test12.addSubElements(test121, test122, test123);
+            test2.addSubElements(test21, test22);
+            test21.addSubElements(test211, test212, test213);
+            test22.addSubElements(test221, test222, test223);
+
+            test1.persist(context);
+            test2.persist(context);
+        });
+
+        context.persist("src/test/resources/output/testRecursive" + System.currentTimeMillis() + ".xml");
+
+        context.invoke(() -> {
+            test1.delete();
+            test2.delete();
+        });
+
+        context.invoke(() -> {
+            test1.persist(context);
+            test1.addSubElements(test11, test12);
+            test11.addSubElements(test111, test112, test113);
+            test12.addSubElements(test121, test122, test123);
+
+            test2.persist(context);
+            test2.addSubElements(test21, test22);
+            test21.addSubElements(test211, test212, test213);
+            test22.addSubElements(test221, test222, test223);
+        });
+
+        List<XmlElement> elements = context.getElements();
+        List<XmlElement> elementsRecursive = context.getElementsRecursive();
+        assertEquals(elements.size(), 2);
+        assertEquals(elementsRecursive.size(), 18);
+
+        List<XmlElement> subElements = test1.getSubElements();
+        List<XmlElement> subElementsRecursive = test1.getSubElementsRecursive();
+        assertEquals(subElements.size(), 2);
+        assertEquals(subElementsRecursive.size(), 8);
+
+        assertEquals(test122.getParent(), test12);
+        assertTrue(test22.getSubElements().contains(test222));
+    }
+
+    @Override
+    protected JxpBackend setupJxp() {
+        return new JxpBuilder().build();
+    }
+}

--- a/src/test/java/net/robinfriedli/jxp/api/XmlElementModificationTest.java
+++ b/src/test/java/net/robinfriedli/jxp/api/XmlElementModificationTest.java
@@ -1,0 +1,170 @@
+package net.robinfriedli.jxp.api;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.testng.annotations.*;
+
+import com.google.common.collect.Lists;
+import com.google.common.truth.Truth;
+import net.robinfriedli.jxp.AbstractTest;
+import net.robinfriedli.jxp.entities.City;
+import net.robinfriedli.jxp.entities.Country;
+import net.robinfriedli.jxp.entities.State;
+import net.robinfriedli.jxp.entities.TestElem;
+import net.robinfriedli.jxp.persist.Context;
+import net.robinfriedli.jxp.queries.QueryResult;
+import net.robinfriedli.jxp.queries.ResultStream;
+
+import static net.robinfriedli.jxp.queries.Conditions.*;
+import static org.testng.Assert.*;
+
+public class XmlElementModificationTest extends AbstractTest {
+
+    @Override
+    protected JxpBackend setupJxp() {
+        return new JxpBuilder()
+            .mapClass("city", City.class)
+            .mapClass("state", State.class)
+            .mapClass("country", Country.class)
+            .build();
+    }
+
+    @Test
+    public void testRemoveAttribute() {
+        doWithCopiedContext("/countries.xml", context -> {
+            State zurich = context.requireElement("Zurich", State.class);
+            context.invoke(() -> zurich.removeAttribute("population"));
+
+            XmlAttribute provisionalPopulation = zurich.getAttribute("population");
+            assertEquals(provisionalPopulation.getClass(), XmlAttribute.Provisional.class);
+            assertEquals(provisionalPopulation.getValue(), "");
+            assertEquals((int) provisionalPopulation.getValue(Integer.class), 0);
+
+            Country unitedKingdom = context.requireElement("United Kingdom", Country.class);
+            context.invoke(() -> unitedKingdom.getAttribute("englishName").remove());
+            expectException(IllegalArgumentException.class, () -> unitedKingdom.getAttribute("englishName").remove());
+        });
+    }
+
+    @Test
+    public void testSimpleElementChange() {
+        Context context = jxp.createContext(getTestResource("/countries.xml"));
+        City london = new City("London", 8908000);
+        XmlElement unitedKingdom = context.requireElement("United Kingdom");
+
+        context.invoke(() -> unitedKingdom.addSubElement(london));
+
+        context.invoke(() -> {
+            XmlElement originalLondon = unitedKingdom.query(and(
+                attribute("population").is(8900000),
+                attribute("name").is("London")
+            )).requireOnlyResult();
+            originalLondon.delete();
+        });
+
+        XmlElement effectiveLondon = unitedKingdom.query(attribute("name").is("London")).getOnlyResult();
+        assertNotNull(effectiveLondon);
+        assertEquals(effectiveLondon.getAttribute("population").getInt(), 8908000);
+        assertEquals(context.query(and(
+            attribute("name").is("London"),
+            parentMatches(attribute("englishName").is("United Kingdom"))
+        )).count(), 1);
+    }
+
+    @Test
+    public void testInsertDelete() {
+        doWithCopiedContext("/countries.xml", context -> {
+            XmlElement england = context.requireElement("England");
+            City london = england.requireSubElement("London", City.class);
+            City manchester = england.requireSubElement("Manchester", City.class);
+
+            context.invoke(() -> england.removeSubElement(london));
+            context.invoke(() -> england.addSubElement(london));
+
+            assertTrue(england.getSubElements().contains(london));
+            assertEquals(london.getParent(), england);
+
+            context.invoke(() -> {
+                england.removeSubElement(london);
+                england.addSubElement(london);
+            });
+
+            assertTrue(england.getSubElements().contains(london));
+            assertEquals(london.getParent(), england);
+
+            context.invoke(() -> {
+                List<XmlElement> subElements = Lists.newArrayList(england.getSubElements());
+                england.delete();
+                england.persist(context);
+                england.addSubElements(subElements);
+            });
+
+            assertEquals(england.getSubElements().size(), 2);
+            assertTrue(england.getSubElements().contains(london));
+
+            City birmingham = new City("Birmingham", 1000000);
+            context.invoke(() -> {
+                england.addSubElement(birmingham);
+                england.delete();
+                birmingham.delete();
+                england.persist(context);
+                england.addSubElement(birmingham);
+                england.addSubElement(london);
+            });
+
+            assertEquals(england.getSubElements().size(), 2);
+            assertTrue(england.getSubElements().contains(london));
+            assertTrue(england.getSubElements().contains(birmingham));
+
+            context.invoke(true, false, () -> {
+                england.delete();
+                england.addSubElement(london);
+                england.removeSubElement(london);
+                england.addSubElement(london);
+                england.addSubElement(birmingham);
+                england.persist(context);
+                england.addSubElement(manchester);
+                birmingham.setAttribute("population", "1086000");
+            });
+
+            assertEquals(england.getSubElements().size(), 3);
+            assertEquals(birmingham.getAttribute("population").getInt(), 1086000);
+        });
+    }
+
+    @Test
+    public void testElementCopy() {
+        doWithCopiedContext("/countries.xml", context -> {
+            ResultStream<Country> query = context.query(attribute("englishName").is("Switzerland"), Country.class);
+            QueryResult<Country, Set<Country>> result = query.getResult(Collectors.toSet());
+            System.out.println(result.requireOnlyResult());
+
+            TestElem elem = context.invoke(() -> {
+                TestElem test = new TestElem("test", "test");
+                test.addSubElement(new TestElem("test1", "test1"));
+                test.addSubElement(new TestElem("test2", "test2"));
+                test.persist(context);
+                return test;
+            });
+
+            context.invoke(() -> {
+                XmlElement copy = elem.copy(true, true);
+                elem.setTextContent("test");
+                assertEquals(elem.getTextContent(), "test");
+                assertEquals(copy.getTextContent(), "");
+                assertEquals(copy.getAttribute("testAtr1").getValue(), "test");
+                assertEquals(copy.getAttribute("testAtr2").getValue(), "test");
+                List<XmlElement> subElements = copy.getSubElements();
+                assertEquals(subElements.size(), 2);
+                for (XmlElement subElement : subElements) {
+                    Truth.assertThat(subElement.getAttribute("testAtr1").getValue()).isAnyOf("test1", "test2");
+                    Truth.assertThat(subElement.getAttribute("testAtr2").getValue()).isAnyOf("test1", "test2");
+                }
+                elem.delete();
+            });
+        });
+    }
+
+}

--- a/src/test/java/net/robinfriedli/jxp/entities/City.java
+++ b/src/test/java/net/robinfriedli/jxp/entities/City.java
@@ -1,0 +1,46 @@
+package net.robinfriedli.jxp.entities;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import net.robinfriedli.jxp.api.AbstractXmlElement;
+import net.robinfriedli.jxp.api.XmlElement;
+import net.robinfriedli.jxp.persist.Context;
+import org.w3c.dom.Element;
+
+public class City extends AbstractXmlElement {
+
+    @SuppressWarnings("unused")
+    public City(Element element, Context context) {
+        super(element, context);
+    }
+
+    @SuppressWarnings("unused")
+    public City(Element element, List<XmlElement> subElements, Context context) {
+        super(element, subElements, context);
+    }
+
+    public City(String tagName, Map<String, ?> attributeMap, List<XmlElement> subElements, String textContent) {
+        super(tagName, attributeMap, subElements, textContent);
+    }
+
+    public City(String name, int population) {
+        super("city", buildAttributes(name, population));
+    }
+
+    private static Map<String, ?> buildAttributes(String name, int population) {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("name", name);
+        attributes.put("population", population);
+        return attributes;
+    }
+
+    @Nullable
+    @Override
+    public String getId() {
+        return getAttribute("name").getValue();
+    }
+}

--- a/src/test/java/net/robinfriedli/jxp/entities/Continent.java
+++ b/src/test/java/net/robinfriedli/jxp/entities/Continent.java
@@ -1,0 +1,43 @@
+package net.robinfriedli.jxp.entities;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import net.robinfriedli.jxp.api.AbstractXmlElement;
+import net.robinfriedli.jxp.api.XmlElement;
+import net.robinfriedli.jxp.persist.Context;
+import org.w3c.dom.Element;
+
+public class Continent extends AbstractXmlElement {
+
+    public Continent(String name) {
+        super("continent", getAttributeMap(name));
+    }
+
+    @SuppressWarnings("unused")
+    public Continent(Element element, Context context) {
+        super(element, context);
+    }
+
+    @SuppressWarnings("unused")
+    public Continent(Element element, List<XmlElement> subElements, Context context) {
+        super(element, subElements, context);
+    }
+
+    private static Map<String, ?> getAttributeMap(String name) {
+        Map<String, Object> attributeMap = new HashMap<>();
+        attributeMap.put("name", name);
+
+        return attributeMap;
+    }
+
+    @Nullable
+    @Override
+    public String getId() {
+        return getAttribute("name").getValue();
+    }
+
+}

--- a/src/test/java/net/robinfriedli/jxp/entities/Country.java
+++ b/src/test/java/net/robinfriedli/jxp/entities/Country.java
@@ -1,0 +1,55 @@
+package net.robinfriedli.jxp.entities;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.Lists;
+import net.robinfriedli.jxp.api.AbstractXmlElement;
+import net.robinfriedli.jxp.api.XmlElement;
+import net.robinfriedli.jxp.persist.Context;
+import org.w3c.dom.Element;
+
+public class Country extends AbstractXmlElement {
+
+    // invoked by JXP
+    @SuppressWarnings("unused")
+    public Country(Element element, Context context) {
+        super(element, context);
+    }
+
+    // invoked by JXP
+    @SuppressWarnings("unused")
+    public Country(Element element, List<XmlElement> subElements, Context context) {
+        super(element, subElements, context);
+    }
+
+    public Country() {
+        super("country");
+    }
+
+    public Country(String name, String englishName, boolean sovereign, List<City> cities) {
+        super("country", buildAttributes(name, englishName, sovereign), Lists.newArrayList(cities));
+    }
+
+
+    public Country(String tagName, Map<String, ?> attributeMap, List<XmlElement> subElements, String textContent) {
+        super(tagName, attributeMap, subElements, textContent);
+    }
+
+    private static Map<String, ?> buildAttributes(String name, String englishName, boolean sovereign) {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("name", name);
+        attributes.put("englishName", englishName);
+        attributes.put("sovereign", sovereign);
+        return attributes;
+    }
+
+    @Nullable
+    @Override
+    public String getId() {
+        return getAttribute("englishName").getValue();
+    }
+}

--- a/src/test/java/net/robinfriedli/jxp/entities/State.java
+++ b/src/test/java/net/robinfriedli/jxp/entities/State.java
@@ -1,0 +1,44 @@
+package net.robinfriedli.jxp.entities;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.Lists;
+import net.robinfriedli.jxp.api.AbstractXmlElement;
+import net.robinfriedli.jxp.api.XmlElement;
+import net.robinfriedli.jxp.persist.Context;
+import org.w3c.dom.Element;
+
+public class State extends AbstractXmlElement {
+
+    @SuppressWarnings("unused")
+    public State(Element element, Context context) {
+        super(element, context);
+    }
+
+    @SuppressWarnings("unused")
+    public State(Element element, List<XmlElement> subElements, Context context) {
+        super(element, subElements, context);
+    }
+
+    public State(String name, int population, List<City> cities) {
+        super("state", buildAttributeMap(name, population), Lists.newArrayList(cities));
+    }
+
+    private static Map<String, ?> buildAttributeMap(String name, int population) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("name", name);
+        map.put("population", population);
+        return map;
+    }
+
+    @Nullable
+    @Override
+    public String getId() {
+        return getAttribute("name").getValue();
+    }
+
+}

--- a/src/test/java/net/robinfriedli/jxp/entities/TestElem.java
+++ b/src/test/java/net/robinfriedli/jxp/entities/TestElem.java
@@ -1,0 +1,40 @@
+package net.robinfriedli.jxp.entities;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import net.robinfriedli.jxp.api.AbstractXmlElement;
+import net.robinfriedli.jxp.api.XmlElement;
+import net.robinfriedli.jxp.persist.Context;
+import org.w3c.dom.Element;
+
+public class TestElem extends AbstractXmlElement {
+
+    public TestElem(String atr1, String atr2) {
+        super("test", buildAttributeMap(atr1, atr2));
+    }
+
+    public TestElem(Element element, Context context) {
+        super(element, context);
+    }
+
+    public TestElem(Element element, List<XmlElement> subElements, Context context) {
+        super(element, subElements, context);
+    }
+
+    private static Map<String, String> buildAttributeMap(String testAtr1, String testAtr2) {
+        Map<String, String> attributeMap = new HashMap<>();
+        attributeMap.put("testAtr1", testAtr1);
+        attributeMap.put("testAtr2", testAtr2);
+        return attributeMap;
+    }
+
+    @Nullable
+    @Override
+    public String getId() {
+        return getAttribute("testAtr1").getValue();
+    }
+}

--- a/src/test/java/net/robinfriedli/jxp/events/ListenerTest.java
+++ b/src/test/java/net/robinfriedli/jxp/events/ListenerTest.java
@@ -1,0 +1,288 @@
+package net.robinfriedli.jxp.events;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+import org.testng.annotations.*;
+
+import com.google.common.collect.Lists;
+import net.robinfriedli.jxp.AbstractTest;
+import net.robinfriedli.jxp.api.JxpBackend;
+import net.robinfriedli.jxp.api.JxpBuilder;
+import net.robinfriedli.jxp.api.XmlElement;
+import net.robinfriedli.jxp.entities.City;
+import net.robinfriedli.jxp.entities.Country;
+import net.robinfriedli.jxp.entities.State;
+import net.robinfriedli.jxp.exec.QueuedTask;
+import net.robinfriedli.jxp.persist.Context;
+import net.robinfriedli.jxp.persist.Transaction;
+
+import static net.robinfriedli.jxp.queries.Conditions.*;
+import static org.testng.Assert.*;
+
+public class ListenerTest extends AbstractTest {
+
+    @Override
+    protected JxpBackend setupJxp() {
+        return new JxpBuilder()
+            .mapClass("city", City.class)
+            .mapClass("state", State.class)
+            .mapClass("country", Country.class)
+            .build();
+    }
+
+    @Test
+    public void testInvokeWithoutListeners() {
+        TestTrigger testTrigger = new TestTrigger();
+        jxp.addListener(testTrigger);
+        Context context = jxp.createContext(getTestResource("/countries.xml"));
+
+        context.invokeWithoutListeners(() -> {
+            context.requireElement("Switzerland").delete();
+            XmlElement unitedKingdom = context.requireElement("United Kingdom");
+            XmlElement london = unitedKingdom.query(attribute("name").is("London")).requireOnlyResult();
+            london.setAttribute("population", 32);
+            Country newCountry = new Country();
+            newCountry.persist(context);
+        });
+
+        QueuedTask<Void> queuedTask = context.futureInvoke(true, true, false, false, false, () -> {
+            XmlElement greaterManchester = context.requireElement("Greater Manchester");
+            greaterManchester.setAttribute("population", 3);
+            greaterManchester.requireSubElement("Manchester").delete();
+
+            return null;
+        });
+
+        Thread t = new Thread(queuedTask);
+        t.start();
+
+        try {
+            t.join();
+        } catch (InterruptedException ignored) {
+        }
+
+        jxp.removeListener(testTrigger);
+        assertFalse(testTrigger.isTriggered());
+    }
+
+    @Test
+    public void testListenerModifications() {
+        TestListener listener = new TestListener();
+        jxp.addListener(listener);
+        try {
+            doWithCopiedContext("/countries.xml", context -> {
+                XmlElement england = context.requireElement("England");
+                XmlElement france = context.requireElement("France");
+
+                context.invoke(() -> {
+                    france.delete();
+                    england.delete();
+                });
+
+                XmlElement london = england.requireSubElement("London");
+                assertEquals(london.getAttribute("population").getInt(), 8900001);
+                XmlElement retrievedFrance = context.getElement("France");
+                assertNotNull(retrievedFrance);
+
+                QueuedTask<City> futureEdinburgh = context.invoke(() -> {
+                    Country scotland = new Country("Scotland", "Scotland", false, Lists.newArrayList());
+                    return context.futureInvoke(() -> {
+                        scotland.persist(context);
+                        City edinburgh = new City("Edinburgh", 500000);
+                        scotland.addSubElement(edinburgh);
+                        return edinburgh;
+                    });
+                });
+
+                try {
+                    City edinburgh = futureEdinburgh.get();
+                    assertEquals(edinburgh.getAttribute("name").getValue(), "Edinburgh");
+                } catch (InterruptedException ignored) {
+                } catch (ExecutionException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        } finally {
+            jxp.removeListener(listener);
+        }
+    }
+
+    @Test
+    public void testCityManagementListener() {
+        CountryManagementListener countryManagementListener = new CountryManagementListener();
+        jxp.addListener(countryManagementListener);
+        try {
+            doWithCopiedContext("/countries.xml", context -> {
+                context.invokeWithoutListeners(() -> context.requireElement("United Kingdom").delete());
+
+                context.invoke(() -> new Country("United Kingdom", "United Kingdom", true, Lists.newArrayList()).persist(context));
+                XmlElement unitedKingdom = context.requireElement("United Kingdom");
+                List<XmlElement> subElements = unitedKingdom.getSubElements();
+                assertEquals(subElements.size(), 3);
+                XmlElement london = unitedKingdom.getSubElement("London");
+                XmlElement edinburgh = unitedKingdom.getSubElement("Edinburgh");
+                assertNotNull(london);
+                assertNotNull(edinburgh);
+
+                XmlElement england = context.requireElement("England");
+                context.invoke(() -> {
+                    City birmingham = new City("Birmingham", 1000000);
+                    england.addSubElement(birmingham);
+                });
+
+                List<XmlElement> subElements1 = unitedKingdom.getSubElements();
+                assertEquals(subElements1.size(), 4);
+                XmlElement birmingham = unitedKingdom.getSubElement("Birmingham");
+                assertNotNull(birmingham);
+                assertEquals(birmingham.getAttribute("population").getInt(), 1000000);
+                assertEquals(unitedKingdom.getAttribute("cityCount").getInt(), 4);
+                assertEquals(england.getAttribute("cityCount").getInt(), 3);
+            });
+        } finally {
+            jxp.removeListener(countryManagementListener);
+        }
+    }
+
+    private static class TestListener extends JxpEventListener {
+
+        @Override
+        public void transactionApplied(Transaction transaction) {
+            List<XmlElement> deleted = transaction
+                .getDeletedElements()
+                .stream()
+                .filter(event -> event.getSource() instanceof Country)
+                .filter(event -> !event.getSource().getAttribute("sovereign").getBool())
+                .map(Event::getSource)
+                .collect(Collectors.toList());
+
+            if (!deleted.isEmpty()) {
+                XmlElement england = deleted.get(0);
+                City london = new City("London", 8900001);
+                City manchester = new City("Manchester", 510000);
+                england.addSubElements(london, manchester);
+                england.persist(transaction.getContext());
+            }
+        }
+
+        @Override
+        public void onBeforeFlush(Transaction transaction) {
+            List<XmlElement> deleted = transaction
+                .getDeletedElements()
+                .stream()
+                .filter(event -> event.getSource() instanceof Country)
+                .filter(event -> event.getSource().getAttribute("sovereign").getBool())
+                .map(Event::getSource)
+                .collect(Collectors.toList());
+
+            if (!deleted.isEmpty()) {
+                transaction.getContext().futureInvoke(() -> {
+                    XmlElement france = deleted.get(0);
+                    City paris = new City("Paris", 2000000);
+                    france.addSubElement(paris);
+                    france.persist(transaction.getContext());
+                    return null;
+                });
+            }
+        }
+
+    }
+
+    private static class CountryManagementListener extends JxpEventListener {
+
+        @Override
+        public void elementCreating(ElementCreatedEvent event) {
+            XmlElement source = event.getSource();
+            Context context = source.getContext();
+
+            if (source instanceof Country && source.getAttribute("englishName").getValue().equals("United Kingdom")) {
+                for (XmlElement englandCity : context.requireElement("England").getSubElements()) {
+                    source.addSubElement(englandCity.copy(true, true));
+                }
+
+                for (XmlElement scotlandCity : context.requireElement("Scotland").getSubElements()) {
+                    source.addSubElement(scotlandCity.copy(true, true));
+                }
+
+                source.setAttribute("cityCount", source.getSubElements().size());
+            }
+
+            if (source instanceof City) {
+                XmlElement country = source.getParent();
+                if (country.hasAttribute("cityCount")) {
+                    int cityCount = country.getAttribute("cityCount").getInt() + 1;
+                    country.setAttribute("cityCount", cityCount);
+                } else {
+                    country.setAttribute("cityCount", country.getSubElements().size());
+                }
+            }
+        }
+
+        @Override
+        public void onBeforeFlush(Transaction transaction) {
+            Context context = transaction.getContext();
+            List<XmlElement> createdCities = transaction
+                .getCreatedElements()
+                .stream()
+                .map(Event::getSource)
+                .filter(e -> e instanceof City)
+                .collect(Collectors.toList());
+
+            if (!createdCities.isEmpty()) {
+                context.futureInvoke(() -> {
+                    for (XmlElement city : createdCities) {
+                        String countryName = city.getParent().getAttribute("englishName").getValue();
+                        if (countryName.equals("England") || countryName.equals("Scotland")) {
+                            XmlElement unitedKingdom = context.requireElement("United Kingdom");
+                            unitedKingdom.addSubElement(city.copy(true, true));
+                        }
+                    }
+
+                    return null;
+                });
+            }
+        }
+
+    }
+
+    private static class TestTrigger extends JxpEventListener {
+
+        private boolean triggered;
+
+        @Override
+        public void elementCreating(ElementCreatedEvent event) {
+            triggered = true;
+        }
+
+        @Override
+        public void elementDeleting(ElementDeletingEvent event) {
+            triggered = true;
+        }
+
+        @Override
+        public void elementChanging(ElementChangingEvent event) {
+            triggered = true;
+        }
+
+        @Override
+        public void transactionApplied(Transaction transaction) {
+            triggered = true;
+        }
+
+        @Override
+        public void transactionCommitted(Transaction transaction) {
+            triggered = true;
+        }
+
+        @Override
+        public void onBeforeFlush(Transaction transaction) {
+            triggered = true;
+        }
+
+        boolean isTriggered() {
+            return triggered;
+        }
+    }
+
+}

--- a/src/test/java/net/robinfriedli/jxp/persist/BindableContextTest.java
+++ b/src/test/java/net/robinfriedli/jxp/persist/BindableContextTest.java
@@ -1,0 +1,77 @@
+package net.robinfriedli.jxp.persist;
+
+import org.testng.annotations.*;
+
+import com.google.common.collect.Lists;
+import net.robinfriedli.jxp.AbstractTest;
+import net.robinfriedli.jxp.api.JxpBackend;
+import net.robinfriedli.jxp.api.JxpBuilder;
+import net.robinfriedli.jxp.api.XmlElement;
+import net.robinfriedli.jxp.entities.City;
+import net.robinfriedli.jxp.entities.Country;
+import net.robinfriedli.jxp.entities.State;
+
+import static net.robinfriedli.jxp.queries.Conditions.*;
+import static org.junit.Assert.*;
+
+public class BindableContextTest extends AbstractTest {
+
+    @Override
+    protected JxpBackend setupJxp() {
+        return new JxpBuilder()
+            .mapClass("city", City.class)
+            .mapClass("state", State.class)
+            .mapClass("country", Country.class)
+            .build();
+    }
+
+    @Test
+    public void testCreateAndRetrieveBoundContext() {
+        Context context = jxp.createContext(getTestResource("/countries.xml"));
+        Context.BindableContext<String> c1 = context.copy("c1");
+        Context.BindableContext<String> c2 = context.copy("c2");
+        jxp.attachContext(c1);
+        jxp.attachContext(c2);
+
+        c1.invoke(() -> {
+            City rome = new City("Rome", 2800000);
+            State state = new State("Lazio", 5800000, Lists.newArrayList(rome));
+            Country italy = new Country("Italia", "Italy", true, Lists.newArrayList());
+            italy.addSubElement(state);
+            italy.setAttribute("population", 60480000);
+            italy.persist(c1);
+        });
+
+        c2.invoke(() -> {
+            City barcelona = new City("Barcelona", 1600000);
+            State state = new State("Province of Barcelona", 5600000, Lists.newArrayList(barcelona));
+            Country spain = new Country("Espana", "Spain", true, Lists.newArrayList());
+            spain.addSubElement(state);
+            spain.setAttribute("population", 46700000);
+            spain.persist(c2);
+        });
+
+        c1.persist("src/test/resources/output/BindableContextTest@testCreateAndRetrieveBoundContext-C1-" + System.currentTimeMillis() + ".xml");
+        c2.persist("src/test/resources/output/BindableContextTest@testCreateAndRetrieveBoundContext-C2-" + System.currentTimeMillis() + ".xml");
+
+        Context.BindableContext<String> context1 = jxp.getBoundContext("c1");
+        Context.BindableContext<String> context2 = jxp.getBoundContext("c2");
+        assertNotNull(context1);
+        assertNotNull(context2);
+
+        XmlElement italy = context1.query(attribute("englishName").is("Italy")).getOnlyResult();
+        XmlElement italy1 = context2.query(attribute("englishName").is("Italy")).getOnlyResult();
+        XmlElement italy2 = context.query(attribute("englishName").is("Italy")).getOnlyResult();
+        assertNotNull(italy);
+        assertNull(italy1);
+        assertNull(italy2);
+        assertEquals(italy.getAttribute("population").getInt(), 60480000);
+        XmlElement lazio = italy.getSubElement("Lazio");
+        assertNotNull(lazio);
+
+        XmlElement provinceOfBarcelona = c2.query(attribute("name").is("Province of Barcelona")).getOnlyResult();
+        assertNotNull(provinceOfBarcelona);
+        assertEquals(provinceOfBarcelona.getAttribute("population").getInt(), 5600000);
+    }
+
+}

--- a/src/test/java/net/robinfriedli/jxp/persist/CopyContextTest.java
+++ b/src/test/java/net/robinfriedli/jxp/persist/CopyContextTest.java
@@ -1,0 +1,67 @@
+package net.robinfriedli.jxp.persist;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.testng.annotations.*;
+
+import net.robinfriedli.jxp.AbstractTest;
+import net.robinfriedli.jxp.api.JxpBackend;
+import net.robinfriedli.jxp.api.JxpBuilder;
+import net.robinfriedli.jxp.api.XmlAttribute;
+import net.robinfriedli.jxp.entities.City;
+import net.robinfriedli.jxp.entities.Continent;
+import net.robinfriedli.jxp.entities.Country;
+import net.robinfriedli.jxp.entities.State;
+
+public class CopyContextTest extends AbstractTest {
+
+    @Override
+    protected JxpBackend setupJxp() {
+        return new JxpBuilder()
+            .mapClass("city", City.class)
+            .mapClass("state", State.class)
+            .mapClass("country", Country.class)
+            .mapClass("continent", Continent.class)
+            .build();
+    }
+
+    @Test
+    public void testCopyAndMutateFullCountryFile() {
+        Context sourceContext = jxp.getContext("src/test/resources/fullcountries-raw.xml");
+        Context context = sourceContext.copy();
+        List<Country> countries = context.getInstancesOf(Country.class);
+        context.invoke(() -> {
+            Map<String, Continent> continentMap = new HashMap<>();
+            for (Country country : countries) {
+                // add "name" attribute and set it the value of the text content, then drop the text content
+                country.setAttribute("name", country.getTextContent());
+                country.setTextContent("");
+
+                // create or get the continent element matching the continent attribute then add the country as its sub element
+                XmlAttribute continentAttr = country.getAttribute("continent");
+                Continent continent = getOrCreateContinent(continentMap, continentAttr.getValue(), context);
+                continentAttr.remove();
+                country.delete();
+                continent.addSubElement(country);
+            }
+        });
+
+        context.persist("src/test/resources/output/fullcountries-dest-" + System.currentTimeMillis() + ".xml");
+    }
+
+    private Continent getOrCreateContinent(Map<String, Continent> continentMap, String name, Context context) {
+        Continent continent = continentMap.get(name);
+
+        if (continent != null) {
+            return continent;
+        } else {
+            Continent newContinent = new Continent(name);
+            continentMap.put(name, newContinent);
+            newContinent.persist(context);
+            return newContinent;
+        }
+    }
+
+}

--- a/src/test/java/net/robinfriedli/jxp/persist/LazyContextTest.java
+++ b/src/test/java/net/robinfriedli/jxp/persist/LazyContextTest.java
@@ -1,0 +1,205 @@
+package net.robinfriedli.jxp.persist;
+
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.testng.annotations.*;
+
+import com.google.common.collect.Lists;
+import com.google.common.truth.Truth;
+import net.robinfriedli.jxp.AbstractTest;
+import net.robinfriedli.jxp.api.JxpBackend;
+import net.robinfriedli.jxp.api.JxpBuilder;
+import net.robinfriedli.jxp.api.UninitializedParent;
+import net.robinfriedli.jxp.api.XmlElement;
+import net.robinfriedli.jxp.entities.City;
+import net.robinfriedli.jxp.entities.Country;
+import net.robinfriedli.jxp.queries.Conditions;
+import net.robinfriedli.jxp.queries.xpath.XQuery;
+import net.robinfriedli.jxp.queries.xpath.XQueryBuilder;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import static net.robinfriedli.jxp.queries.xpath.XConditions.*;
+import static org.testng.Assert.*;
+
+public class LazyContextTest extends AbstractTest {
+
+    @Override
+    protected JxpBackend setupJxp() {
+        return new JxpBuilder()
+            .setDefaultContextType(JxpBackend.DefaultContextType.LAZY)
+            .mapClass("country", Country.class)
+            .mapClass("city", City.class)
+            .build();
+    }
+
+    @Test
+    public void testXPathQuery() throws ParserConfigurationException {
+        City london = new City("London", 8900000);
+        City manchester = new City("Manchester", 500000);
+        City birmingham = new City("Birmingham", 1000000);
+
+        City zurich = new City("Zurich", 400000);
+        City geneva = new City("Geneva", 200000);
+
+        City newYork = new City("New York", 8800000);
+        City sanFrancisco = new City("San Francisco", 880000);
+        City chicago = new City("Chicago", 2700000);
+
+        Country uk = new Country("United Kingdom", "United Kingdom", true, Lists.newArrayList(london, manchester, birmingham));
+        Country switzerland = new Country("Schweiz", "Switzerland", true, Lists.newArrayList(zurich, geneva));
+        Country england = new Country("England", "England", false, Lists.newArrayList());
+        Country us = new Country("United States", "United States", true, Lists.newArrayList(newYork, sanFrancisco, chicago));
+
+        Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element rootElem = document.createElement("countries");
+        rootElem.setAttribute("xmlns", "countrySpace");
+        document.appendChild(rootElem);
+
+        Context context = jxp.getContext(document);
+        context.persist("src/test/resources/output/xPathQueryTest" + System.currentTimeMillis() + ".xml");
+        context.invoke(() -> {
+            uk.persist(context);
+            switzerland.persist(context);
+            england.addSubElement(london.copy(true, true));
+            england.addSubElement(birmingham.copy(true, true));
+            england.persist(context);
+            us.persist(context);
+        });
+
+        XQuery query = XQueryBuilder.find("country/city").where(and(
+            or(
+                attribute("population").greaterEquals(1000000),
+                attribute("population").is(400000)
+            ),
+            or(
+                attribute("name").startsWith("Zu"),
+                attribute("name").endsWith("on"),
+                attribute("name").contains("ew")
+            )
+        ));
+        String xPath = query.getXPath(context);
+        List<XmlElement> xmlElements = context.xPathQuery(xPath);
+        assertEquals(xmlElements.size(), 4);
+        for (XmlElement xmlElement : xmlElements) {
+            assertTrue(xmlElement.getParent() instanceof UninitializedParent);
+            Truth.assertThat(xmlElement.getAttribute("name").getValue()).isAnyOf("London", "Zurich", "New York");
+            String parentName = xmlElement.getParent().getAttribute("englishName").getValue();
+            XmlElement parent = xmlElement.getParent();
+            assertFalse(parent instanceof UninitializedParent);
+            Truth.assertThat(parentName).isAnyOf("United Kingdom", "England", "United States", "Switzerland");
+            assertTrue(parent.getSubElements().contains(xmlElement));
+            switch (parentName) {
+                case "United Kingdom":
+                case "United States":
+                    assertEquals(parent.getSubElements().size(), 3);
+                    break;
+                case "England":
+                case "Switzerland":
+                    assertEquals(parent.getSubElements().size(), 2);
+                    break;
+                default:
+                    fail();
+                    break;
+            }
+        }
+
+        XQuery query1 = XQueryBuilder.find("country").where(and(
+            or(
+                and(
+                    attribute("sovereign").is(false),
+                    attribute("englishName").startsWith("Eng"),
+                    attribute("name").contains("ngl"),
+                    attribute("name").endsWith("land")
+                ),
+                attribute("name").startsWith("United"),
+                attribute("englishName").endsWith("land")
+            ),
+            not(
+                and(
+                    attribute("name").startsWith("United"),
+                    attribute("name").endsWith("States")
+                )
+            )
+        ));
+        String xPath1 = query1.getXPath(context);
+        List<XmlElement> xmlElements1 = context.xPathQuery(xPath1);
+        assertEquals(xmlElements1.size(), 3);
+        for (XmlElement xmlElement : xmlElements1) {
+            Truth.assertThat(xmlElement.getAttribute("name").getValue()).isAnyOf("United Kingdom", "Schweiz", "England");
+        }
+
+        XQuery query2 = XQueryBuilder.find("country/city").where(or(
+            and(
+                not(
+                    and(
+                        attribute("population").in(200000, 400000, 1000000, 8900000),
+                        attribute("name").in("Birmingham", "New York")
+                    )
+                ),
+                attribute("population").greaterThan(200000),
+                attribute("population").lowerThan(1000000)
+            ),
+            and(
+                or(
+                    attribute("population").greaterThan(8000000),
+                    attribute("population").lowerThan(1000000)
+                ),
+                attribute("name").in("London", "Manchester", "Birmingham"),
+                not(
+                    or(
+                        attribute("name").in("New York"),
+                        attribute("name").contains("ches"),
+                        attribute("name").endsWith("ham")
+                    )
+                )
+            )
+        ));
+        String xPath2 = query2.getXPath(context);
+        List<XmlElement> xmlElements2 = context.xPathQuery(xPath2);
+        assertEquals(xmlElements2.size(), 5);
+        for (XmlElement xmlElement : xmlElements2) {
+            Truth.assertThat(xmlElement.getAttribute("name").getValue()).isAnyOf("London", "Manchester", "Zurich", "San Francisco");
+        }
+    }
+
+    @Test
+    public void testLazyParentInitialization() {
+        Context context = jxp.createContext(getTestResource("/countries.xml"));
+
+        String xPath = XQueryBuilder.find("country/state/city").where(
+            attribute("name").is("London")
+        ).getXPath(context);
+
+        List<XmlElement> xmlElements = context.xPathQuery(xPath);
+        assertEquals(xmlElements.size(), 1);
+
+        XmlElement xmlElement = xmlElements.get(0);
+        assertTrue(xmlElement.getParent() instanceof UninitializedParent);
+        String parentName = xmlElement.getParent().getAttribute("name").getValue();
+        XmlElement parent = xmlElement.getParent();
+        assertEquals(parentName, "Greater London");
+        assertFalse(parent instanceof UninitializedParent);
+        assertEquals(parent.getSubElements().size(), 1);
+        assertTrue(parent.getSubElements().contains(xmlElement));
+
+        assertTrue(parent.getParent() instanceof UninitializedParent);
+        String parentParentName = parent.getParent().getAttribute("name").getValue();
+        XmlElement parentParent = parent.getParent();
+        assertEquals(parentParentName, "United Kingdom");
+        assertNull(parentParent.getParent());
+        assertTrue(parentParent instanceof Country);
+        assertEquals(parentParent.getSubElements().size(), 3);
+        assertEquals(parentParent.getSubElementsRecursive().size(), 6);
+
+        XmlElement manchester = parentParent.query(Conditions.attribute("name").is("Manchester")).getOnlyResult();
+        assertNotNull(manchester);
+        XmlElement manchesterParent = manchester.getParent();
+        assertEquals(manchesterParent.getAttribute("name").getValue(), "Greater Manchester");
+        assertEquals(manchesterParent.getParent(), parentParent);
+    }
+
+}

--- a/src/test/java/net/robinfriedli/jxp/persist/TransactionTest.java
+++ b/src/test/java/net/robinfriedli/jxp/persist/TransactionTest.java
@@ -1,0 +1,348 @@
+package net.robinfriedli.jxp.persist;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.testng.annotations.*;
+
+import com.google.common.collect.Lists;
+import net.robinfriedli.jxp.AbstractTest;
+import net.robinfriedli.jxp.api.JxpBackend;
+import net.robinfriedli.jxp.api.JxpBuilder;
+import net.robinfriedli.jxp.api.XmlElement;
+import net.robinfriedli.jxp.entities.City;
+import net.robinfriedli.jxp.entities.Country;
+import net.robinfriedli.jxp.entities.State;
+import net.robinfriedli.jxp.events.JxpEventListener;
+import net.robinfriedli.jxp.exceptions.PersistException;
+import net.robinfriedli.jxp.exec.AbstractTransactionalMode;
+import net.robinfriedli.jxp.exec.Invoker;
+import net.robinfriedli.jxp.exec.QueuedTask;
+import net.robinfriedli.jxp.exec.modes.MutexSyncMode;
+import net.robinfriedli.jxp.queries.Query;
+
+import static net.robinfriedli.jxp.queries.Conditions.*;
+import static org.testng.Assert.*;
+
+public class TransactionTest extends AbstractTest {
+
+    @Override
+    protected JxpBackend setupJxp() {
+        return new JxpBuilder()
+            .mapClass("city", City.class)
+            .mapClass("state", State.class)
+            .mapClass("country", Country.class)
+            .build();
+    }
+
+    @Test
+    public void testSequentialInvoke() {
+        FlushListener flushListener = new FlushListener();
+        jxp.addListener(flushListener);
+        doWithCopiedContext("/countries.xml", context -> {
+            context.invokeSequential(1, () -> {
+                XmlElement switzerland = context.requireElement("Switzerland");
+                switzerland.setAttribute("population", 32);
+                XmlElement zurich = switzerland.requireSubElement("Zurich");
+                zurich.setAttribute("population", 3443);
+                XmlElement unitedKingdom = context.requireElement("United Kingdom");
+                unitedKingdom.setAttribute("name", "test");
+            });
+
+            assertEquals(flushListener.getFlushCount(), 3);
+            jxp.removeListener(flushListener);
+            FlushListener flushListener1 = new FlushListener();
+            jxp.addListener(flushListener1);
+
+            context.invokeSequential(3, () -> {
+                int modCount = 0;
+                for (XmlElement element : context.getElementsRecursive()) {
+                    if (modCount > 5) {
+                        break;
+                    }
+
+                    if (element.hasAttribute("population")) {
+                        element.setAttribute("population", 0);
+                        modCount++;
+                    }
+                }
+            });
+
+            assertEquals(flushListener1.getFlushCount(), 2);
+            jxp.removeListener(flushListener1);
+        });
+    }
+
+    @DataProvider
+    public Object[] boolProvider() {
+        return new Object[]{false, true};
+    }
+
+    @Test(dataProvider = "boolProvider")
+    public void testSynchronisedTransactions(boolean runAsQueuedTask) {
+        AtomicInteger checkpoint = new AtomicInteger(0);
+        doWithCopiedContext("/countries.xml", context -> {
+            Callable<Void> task1 = () -> {
+                assertEquals(checkpoint.getAndIncrement(), 0);
+                try {
+                    XmlElement switzerland = context.getElement("Switzerland");
+                    assertNotNull(switzerland);
+                    switzerland.setAttribute("population", 10000);
+                    State zurich = switzerland.getSubElement("Zurich", State.class);
+                    assertNotNull(zurich);
+
+                    Thread.sleep(1000);
+
+                    XmlElement greaterManchester = context.query(and(
+                        attribute("name").is("Greater Manchester"),
+                        parentMatches(attribute("name").is("United Kingdom"))
+                    )).requireOnlyResult();
+                    greaterManchester.setAttribute("name", "test rename");
+                    greaterManchester.requireSubElement("Manchester").delete();
+
+                    XmlElement greaterLondon = greaterManchester.getParent().requireSubElement("Greater London");
+                    greaterLondon.setAttribute("newarg", "val");
+
+                    XmlElement unitedKingdom = greaterLondon.getParent();
+                    assertEquals(unitedKingdom.getAttribute("name").getValue(), "United Kingdom");
+                    assertFalse(unitedKingdom.hasAttribute("newarg"));
+
+                    Thread.sleep(1000);
+                } finally {
+                    assertEquals(checkpoint.getAndIncrement(), 1);
+                }
+
+                return null;
+            };
+
+            Callable<Void> task2 = () -> {
+                assertEquals(checkpoint.getAndIncrement(), 2);
+                try {
+                    XmlElement switzerland = context.requireElement("Switzerland");
+                    XmlElement unitedKingdom = context.requireElement("United Kingdom");
+                    XmlElement greaterManchester = unitedKingdom.getSubElement("test rename");
+                    XmlElement greaterLondon = unitedKingdom.requireSubElement("Greater London");
+
+                    Thread.sleep(1000);
+
+                    assertEquals(switzerland.getAttribute("population").getInt(), 10000);
+                    assertNotNull(greaterManchester);
+                    XmlElement manchester = greaterManchester.getSubElement("Manchester");
+                    assertNull(manchester);
+
+                    switzerland.setAttribute("englishName", "britzerland");
+
+                    assertEquals(greaterLondon.getAttribute("newarg").getValue(), "val");
+
+                    unitedKingdom.setAttribute("newarg", "val");
+                    unitedKingdom.setAttribute("name", "renamed");
+                } finally {
+                    assertEquals(checkpoint.getAndIncrement(), 3);
+                }
+                return null;
+            };
+
+            Callable<Void> task3 = () -> {
+                assertEquals(checkpoint.getAndIncrement(), 4);
+                try {
+                    XmlElement switzerland = context.getElement("britzerland");
+                    assertNotNull(switzerland);
+                    switzerland.requireSubElement("Zurich").setAttribute("name", "Greater Zurich");
+
+                    List<XmlElement> xmlElements = context.query(attribute("newarg").is("val")).collect();
+                    assertEquals(xmlElements.size(), 2);
+                    XmlElement greaterLondon = Query.evaluate(attribute("name").is("Greater London")).execute(xmlElements).requireOnlyResult();
+                    greaterLondon.setAttribute("newarg", "newval");
+                } finally {
+                    assertEquals(checkpoint.get(), 5);
+                }
+                return null;
+            };
+
+            Thread t1;
+            Thread t2;
+            Thread t3;
+            QueuedTask<Void> queuedTask1 = null;
+            QueuedTask<Void> queuedTask2 = null;
+            QueuedTask<Void> queuedTask3 = null;
+
+
+            if (runAsQueuedTask) {
+                Invoker.Mode mode = Invoker.Mode.create()
+                    .with(new MutexSyncMode(context.getMutexKey()))
+                    .with(AbstractTransactionalMode.Builder.create().build(context));
+                queuedTask1 = context.futureInvoke(false, false, mode, task1);
+                queuedTask2 = context.futureInvoke(false, false, mode, task2);
+                queuedTask3 = context.futureInvoke(false, false, mode, task3);
+                t1 = new Thread(queuedTask1);
+                t2 = new Thread(queuedTask2);
+                t3 = new Thread(queuedTask3);
+            } else {
+                t1 = new Thread(() -> context.invoke(task1));
+                t2 = new Thread(() -> context.invoke(task2));
+                t3 = new Thread(() -> context.invoke(task3));
+            }
+
+            ErrorReportingExceptionHandler exceptionHandler = new ErrorReportingExceptionHandler();
+
+            t1.setUncaughtExceptionHandler(exceptionHandler);
+            t2.setUncaughtExceptionHandler(exceptionHandler);
+            t3.setUncaughtExceptionHandler(exceptionHandler);
+
+            t1.start();
+            try {
+                // make sure thread 2 actually starts second
+                Thread.sleep(20);
+            } catch (InterruptedException ignored) {
+            }
+            t2.start();
+            try {
+                // run thread 3 after thread 1 finished but before thread 2 exits; if we do not wait for thread 1 to finish
+                // and thread 2 and 3 are waiting for the lock at the same time there is no guarantee which one comes first.
+                t1.join();
+            } catch (InterruptedException ignored) {
+            }
+            t3.start();
+
+            try {
+                t1.join();
+                t2.join();
+                t3.join();
+            } catch (InterruptedException ignored) {
+            }
+
+            Throwable error = exceptionHandler.getError();
+            if (error instanceof RuntimeException) {
+                throw (RuntimeException) error;
+            } else if (error != null) {
+                throw new RuntimeException(error);
+            }
+
+            if (runAsQueuedTask) {
+                try {
+                    queuedTask1.get();
+                    queuedTask2.get();
+                    queuedTask3.get();
+                } catch (ExecutionException e) {
+                    throw new RuntimeException(e);
+                } catch (InterruptedException ignored) {
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testSimpleTransaction() {
+        doWithCopiedContext("/countries.xml", context -> {
+            context.invoke(() -> {
+                City zurich = new City("Zurich", 400000);
+                City london = new City("London", 8000000);
+
+                new Country("Schweiz2", "Switzerland2", true, Lists.newArrayList(zurich)).persist(context);
+                new Country("England2", "England2", false, Lists.newArrayList(london)).persist(context);
+            });
+
+            context.invoke(() -> {
+                City geneva = new City("Geneva", 200000);
+                City manchester = new City("Manchester", 500000);
+
+                Country switzerland = context.requireElement("Switzerland2", Country.class);
+                Country england = context.requireElement("England2", Country.class);
+
+                switzerland.addSubElement(geneva);
+                england.addSubElement(manchester);
+            });
+
+            XmlElement switzerland = context.getElement("Switzerland2");
+            assertNotNull(switzerland);
+            XmlElement zurich = switzerland.getSubElement("Zurich");
+            assertNotNull(zurich);
+            assertEquals(zurich.getAttribute("population").getInt(), 400000);
+            XmlElement england = context.getElement("England2");
+            assertNotNull(england);
+            XmlElement london = england.getSubElement("London");
+            assertNotNull(london);
+            assertEquals(london.getAttribute("population").getInt(), 8000000);
+        });
+    }
+
+    @Test
+    public void testRollback() {
+        doWithCopiedContext(false, "/countries.xml", context -> {
+            XmlElement england = context.requireElement("England");
+            XmlElement london = england.requireSubElement("London");
+            context.invoke(() -> {
+                london.setAttribute("population", "8825000");
+                london.delete();
+            });
+
+            context.invoke(() -> england.addSubElement(london));
+
+            // expect CommitException
+            // test if rolling back a committed ElementDeletingElement works when a change made to the same element fails after
+            // that. Normally the next change would not even get committed when the element gets deleted so we need to change the
+            // state and then delete the element manually for the commit to fail
+            expectException(PersistException.class, () -> context.invoke(() -> {
+                england.delete();
+                england.setState(XmlElement.State.CLEAN);
+                england.setAttribute("englishName", "testRollback");
+                england.phantomize();
+            }));
+
+            assertEquals(england.getAttribute("englishName").getValue(), "England");
+
+            // test that the value gets rolled back correctly when changing the same attribute twice (rollback in reverse order
+            // of added changes)
+            expectException(PersistException.class, () -> context.invoke(() -> {
+                england.setAttribute("name", "testRollback");
+                england.setAttribute("name", "testRollback2");
+                england.delete();
+                england.phantomize();
+            }));
+
+            assertEquals(england.getAttribute("name").getValue(), "England");
+        });
+    }
+
+    @Test
+    public void testAsyncTransaction() {
+        doWithCopiedContext(false, "/countries.xml", context -> {
+            QueuedTask<Void> future = context.futureInvoke(true, true, false, false, false, () -> {
+                City englandIsMyCity = new City("England is my City", 60000000);
+                context.requireElement("England").addSubElement(englandIsMyCity);
+                Thread.sleep(100);
+                return null;
+            });
+            new Thread(future).start();
+            long count1 = Query.evaluate(attribute("name").is("England is my City")).execute(context.getElementsRecursive()).count();
+            assertEquals(count1, 0);
+            try {
+                future.get();
+            } catch (InterruptedException e) {
+                return;
+            } catch (ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+            long count2 = Query.evaluate(attribute("name").is("England is my City")).execute(context.getElementsRecursive()).count();
+            assertEquals(count2, 1);
+        });
+    }
+
+    private static class FlushListener extends JxpEventListener {
+
+        private int flushCount;
+
+        @Override
+        public void onBeforeFlush(Transaction transaction) {
+            flushCount++;
+        }
+
+        int getFlushCount() {
+            return flushCount;
+        }
+
+    }
+
+}

--- a/src/test/java/net/robinfriedli/jxp/queries/QueryTest.java
+++ b/src/test/java/net/robinfriedli/jxp/queries/QueryTest.java
@@ -1,0 +1,161 @@
+package net.robinfriedli.jxp.queries;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.testng.annotations.*;
+
+import net.robinfriedli.jxp.AbstractTest;
+import net.robinfriedli.jxp.api.JxpBackend;
+import net.robinfriedli.jxp.api.JxpBuilder;
+import net.robinfriedli.jxp.api.StringConverter;
+import net.robinfriedli.jxp.api.XmlElement;
+import net.robinfriedli.jxp.entities.City;
+import net.robinfriedli.jxp.entities.Continent;
+import net.robinfriedli.jxp.entities.Country;
+import net.robinfriedli.jxp.entities.State;
+import net.robinfriedli.jxp.exceptions.QueryException;
+import net.robinfriedli.jxp.persist.Context;
+
+import static net.robinfriedli.jxp.queries.Conditions.*;
+import static org.testng.Assert.*;
+
+public class QueryTest extends AbstractTest {
+
+    @Override
+    protected JxpBackend setupJxp() {
+        return new JxpBuilder()
+            .mapClass("city", City.class)
+            .mapClass("state", State.class)
+            .mapClass("country", Country.class)
+            .mapClass("continent", Continent.class)
+            .build();
+    }
+
+    @Test
+    public void testOrderByIntegerAttribute() {
+        Context context = jxp.createContext(getTestResource("/fullcountries.xml"));
+        List<Country> sortedCountries = context.query(instanceOf(Country.class), Country.class).order(Order.attribute("iso", Integer.class)).collect();
+
+        assertTrue(sortedCountries.size() > 10);
+
+        assertEquals(sortedCountries.get(0).getAttribute("iso").getInt(), 4);
+        assertEquals(sortedCountries.get(1).getAttribute("iso").getInt(), 8);
+        assertEquals(sortedCountries.get(2).getAttribute("iso").getInt(), 10);
+        assertEquals(sortedCountries.get(3).getAttribute("iso").getInt(), 12);
+        assertEquals(sortedCountries.get(4).getAttribute("iso").getInt(), 16);
+        assertEquals(sortedCountries.get(5).getAttribute("iso").getInt(), 20);
+        assertEquals(sortedCountries.get(6).getAttribute("iso").getInt(), 24);
+        assertEquals(sortedCountries.get(7).getAttribute("iso").getInt(), 28);
+        assertEquals(sortedCountries.get(8).getAttribute("iso").getInt(), 31);
+        assertEquals(sortedCountries.get(9).getAttribute("iso").getInt(), 32);
+    }
+
+    @Test
+    public void testOrderByStringAttribute() {
+        Context context = jxp.createContext(getTestResource("/fullcountries.xml"));
+        List<Country> countries = context.query(instanceOf(Country.class), Country.class).order(Order.attribute("name", Order.Direction.DESCENDING)).collect();
+
+        assertTrue(countries.size() > 10);
+
+        assertEquals(countries.get(0).getAttribute("name").getValue(), "Zimbabwe");
+        assertEquals(countries.get(1).getAttribute("name").getValue(), "Zambia");
+        assertEquals(countries.get(2).getAttribute("name").getValue(), "Zaire");
+        assertEquals(countries.get(3).getAttribute("name").getValue(), "Yugoslavia");
+        assertEquals(countries.get(4).getAttribute("name").getValue(), "Yemen");
+        assertEquals(countries.get(5).getAttribute("name").getValue(), "Western Sahara");
+        assertEquals(countries.get(6).getAttribute("name").getValue(), "Wallis And Futuna Islands");
+        assertEquals(countries.get(7).getAttribute("name").getValue(), "Virgin Islands (U.S.)");
+        assertEquals(countries.get(8).getAttribute("name").getValue(), "Virgin Islands (British)");
+        assertEquals(countries.get(9).getAttribute("name").getValue(), "Vietnam");
+        assertEquals(countries.get(10).getAttribute("name").getValue(), "Venezuela");
+    }
+
+    /**
+     * Queries should fail because they find both a state and city and match the query condition while attempting to
+     * cast the result city.
+     */
+    @Test
+    public void testExpectConversionError() {
+        Context context = jxp.createContext(getTestResource("/countries.xml"));
+        expectException(QueryException.class, () -> context.query(attribute("name").is("Zurich"), City.class).collect());
+        expectException(QueryException.class, () -> context.query(attribute("name").is("Zurich"), City.class).count());
+    }
+
+    @Test
+    public void testSimpleQueries() {
+        Context context = jxp.createContext(getTestResource("/countries.xml"));
+        XmlElement england = context.query(and(
+            attribute("sovereign").is(false),
+            not(attribute("name").is("Scotland"))
+        )).requireOnlyResult();
+        XmlElement switzerland = context.query(attribute("englishName").in("Switzerland", "Swiss", "Schweiz")).requireOnlyResult();
+        XmlElement london = context.query(
+            and(
+                attribute("population").greaterThan(800000),
+                subElementOf(england),
+                instanceOf(City.class),
+                textContent().isEmpty()
+            )
+        ).requireOnlyResult();
+        Set<XmlElement> ldnSet = Query.evaluate(and(
+            attribute("population").greaterThan(8000000),
+            tagName("city")
+        )).execute(context.getElementsRecursive()).collect(Collectors.toSet());
+        assertFalse(england.getAttribute("sovereign").getBool());
+        assertEquals(england.getAttribute("name").getValue(), "England");
+        assertEquals(london.getParent(), england);
+        assertEquals(switzerland.getAttribute("name").getValue(), "Schweiz");
+        assertEquals(ldnSet.iterator().next().getAttribute("name").getValue(), "London");
+
+        List<XmlElement> found = context.query(attribute("name").is(4)).collect();// this no longer throws an exception since 1.1
+        assertEquals(found.size(), 0);
+        expectException(IllegalStateException.class, () -> context.query(attribute("name").is(context)).collect());
+
+        XmlElement unitedKingdom = context.requireElement("United Kingdom");
+        XmlElement foundLondon = context.query(and(
+            attribute("name").is("London"),
+            parentMatches(parentMatches(attribute("name").is("United Kingdom")))
+        )).requireOnlyResult();
+        assertEquals(foundLondon, unitedKingdom.requireSubElement("Greater London").requireSubElement("London"));
+        assertEquals(Query.evaluate(attribute("englishName").startsWith("Swe")).execute(context.getElements()).count(), 1);
+    }
+
+    @Test
+    public void testAddConversion() {
+        Context context = jxp.createContext(getTestResource("/countries.xml"));
+        XmlElement london = context.query(and(
+            attribute("name").is("London"),
+            parentMatches(instanceOf(State.class))
+        )).requireOnlyResult();
+        StringConverter.map(null, City.class, s -> new City(s, 1000), c -> c.getAttribute("name").getValue());
+        assertTrue(StringConverter.canConvert(City.class));
+        City newCity = london.getAttribute("name").getValue(City.class);
+        assertEquals(newCity.getAttribute("population").getInt(), 1000);
+        assertEquals(newCity.getAttribute("name").getValue(), "London");
+    }
+
+    @Test
+    public void testSubElementsMatch() {
+        Context context = jxp.createContext(getTestResource("/countries.xml"));
+        XmlElement unitedKingdom = context.query(allSubElementsMatch(and(
+            or(
+                attribute("name").startsWith("Greater"),
+                attribute("name").contains("Edinburgh")
+            ),
+            parentMatches(attribute("name").startsWith("United"))
+        ))).requireOnlyResult();
+        assertEquals(unitedKingdom.getAttribute("name").getValue(), "United Kingdom");
+
+        XmlElement cityOfEdinburgh = context.query(existsSubElement(and(
+            attribute("name").is("Edinburgh"),
+            parentMatches(instanceOf(State.class))
+        ))).requireOnlyResult();
+
+        assertEquals(cityOfEdinburgh.getAttribute("name").getValue(), "City of Edinburgh");
+        assertTrue(cityOfEdinburgh instanceof State);
+        assertTrue(cityOfEdinburgh.getParent() instanceof Country);
+    }
+
+}

--- a/src/test/resources/countries.xml
+++ b/src/test/resources/countries.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<countries>
+  <country name="Schweiz" englishName="Switzerland" sovereign="true" population="8000000">
+    <state name="Zurich" population="1500000">
+      <city name="Zurich" population="400000"/>
+      <city name="Winterthur" population="100000"/>
+    </state>
+    <state name="Geneva" population="200000">
+      <city name="Geneva" population="200000"/>
+    </state>
+  </country>
+  <country name="United Kingdom" englishName="United Kingdom" sovereign="true" population="66000000">
+    <state name="Greater London" population="8900000">
+      <city name="London" population="8900000"/>
+    </state>
+    <state name="Greater Manchester" population="2800000">
+      <city name="Manchester" population="2800000"/>
+    </state>
+    <state name="City of Edinburgh" population="900000">
+      <city name="Edinburgh" population="500000"/>
+    </state>
+  </country>
+  <country name="England" englishName="England" sovereign="false" population="55980000">
+    <city name="London" population="8900000"/>
+    <city name="Manchester" population="510000"/>
+  </country>
+  <country englishName="Sweden" name="Sverige" sovereign="true">
+    <city name="Stockholm" population="950000"/>
+  </country>
+  <country englishName="France" name="France" sovereign="true">
+    <city name="Paris" population="2000000"/>
+  </country>
+  <country englishName="Scotland" name="Scotland" sovereign="false">
+    <city name="Edinburgh" population="500000"/>
+  </country>
+  <country englishName="Canada" name="Canada" sovereign="true">
+    <city name="Toronto" population="2700000"/>
+  </country>
+</countries>

--- a/src/test/resources/fullcountries-raw.xml
+++ b/src/test/resources/fullcountries-raw.xml
@@ -1,0 +1,267 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<countries>
+  <country code="af" handle="afghanistan" continent="asia" iso="4">Afghanistan</country>
+  <country code="al" handle="albania" continent="europe" iso="8">Albania</country>
+  <country code="dz" handle="algeria" continent="africa" iso="12">Algeria</country>
+  <country code="as" handle="american-samoa" continent="polynesia" iso="16">American Samoa</country>
+  <country code="ad" handle="andorra" continent="europe" iso="20">Andorra</country>
+  <country code="ao" handle="angola" continent="africa" iso="24">Angola</country>
+  <country code="ai" handle="anguilla" continent="north america" iso="660">Anguilla</country>
+  <country code="aq" handle="antarctica" continent="antarctica" iso="10">Antarctica</country>
+  <country code="ag" handle="antigua-and-barbuda" continent="north america" iso="28">Antigua And Barbuda</country>
+  <country code="ar" handle="argentina" continent="south america" iso="32">Argentina</country>
+  <country code="am" handle="armenia" continent="europe" iso="51">Armenia</country>
+  <country code="aw" handle="aruba" continent="north america" iso="533">Aruba</country>
+  <country code="au" handle="australia" continent="australasia" iso="36">Australia</country>
+  <country code="at" handle="austria" continent="europe" iso="40">Austria</country>
+  <country code="az" handle="azerbaijan" continent="europe" iso="31">Azerbaijan</country>
+  <country code="bs" handle="bahamas" continent="north america" iso="44">Bahamas</country>
+  <country code="bh" handle="bahrain" continent="asia" iso="48">Bahrain</country>
+  <country code="bd" handle="bangladesh" continent="asia" iso="50">Bangladesh</country>
+  <country code="bb" handle="barbados" continent="north america" iso="52">Barbados</country>
+  <country code="by" handle="belarus" continent="europe" iso="112">Belarus</country>
+  <country code="be" handle="belgium" continent="europe" iso="56">Belgium</country>
+  <country code="bz" handle="belize" continent="central america" iso="84">Belize</country>
+  <country code="bj" handle="benin" continent="africa" iso="204">Benin</country>
+  <country code="bm" handle="bermuda" continent="north america" iso="60">Bermuda</country>
+  <country code="bt" handle="bhutan" continent="asia" iso="64">Bhutan</country>
+  <country code="bo" handle="bolivia" continent="south america" iso="68">Bolivia</country>
+  <country code="ba" handle="bosnia-and-herzegovina" continent="europe" iso="70">Bosnia And Herzegovina</country>
+  <country code="bw" handle="botswana" continent="africa" iso="72">Botswana</country>
+  <country code="bv" handle="bouvet-island" continent="antarctica" iso="74">Bouvet Island</country>
+  <country code="br" handle="brazil" continent="south america" iso="76">Brazil</country>
+  <country code="io" handle="british-indian-ocean-continent" continent="asia" iso="86">British Indian Ocean continent
+  </country>
+  <country code="bn" handle="brunei-darussalam" continent="asia" iso="96">Brunei Darussalam</country>
+  <country code="bg" handle="bulgaria" continent="europe" iso="100">Bulgaria</country>
+  <country code="bf" handle="burkina-faso" continent="africa" iso="854">Burkina Faso</country>
+  <country code="bi" handle="burundi" continent="africa" iso="108">Burundi</country>
+  <country code="kh" handle="cambodia" continent="asia" iso="116">Cambodia</country>
+  <country code="cm" handle="cameroon" continent="africa" iso="120">Cameroon</country>
+  <country code="ca" handle="canada" continent="north america" iso="124">Canada</country>
+  <country code="cv" handle="cape-verde" continent="africa" iso="132">Cape Verde</country>
+  <country code="ky" handle="cayman-islands" continent="north america" iso="136">Cayman Islands</country>
+  <country code="cf" handle="central-african-republic" continent="africa" iso="140">Central African Republic</country>
+  <country code="td" handle="chad" continent="africa" iso="148">Chad</country>
+  <country code="cl" handle="chile" continent="south america" iso="152">Chile</country>
+  <country code="cn" handle="china" continent="asia" iso="156">China</country>
+  <country code="cx" handle="christmas-island" continent="australasia" iso="162">Christmas Island</country>
+  <country code="cc" handle="cocos-islands" continent="australasia" iso="166">Cocos (Keeling) Islands</country>
+  <country code="co" handle="colombia" continent="south america" iso="170">Colombia</country>
+  <country code="km" handle="comoros" continent="africa" iso="174">Comoros</country>
+  <country code="cg" handle="congo" continent="africa" iso="178">Congo</country>
+  <country code="ck" handle="cook-islands" continent="polynesia" iso="184">Cook Islands</country>
+  <country code="cr" handle="costa-rica" continent="central america" iso="188">Costa Rica</country>
+  <country code="ci" handle="cote-divoire" continent="africa" iso="384">Cote D"Ivoire</country>
+  <country code="hr" handle="croatia" continent="europe" iso="191">Croatia</country>
+  <country code="cu" handle="cuba" continent="central america" iso="192">Cuba</country>
+  <country code="cy" handle="cyprus" continent="europe" iso="196">Cyprus</country>
+  <country code="cz" handle="czech-republic" continent="europe" iso="203">Czech Republic</country>
+  <country code="dk" handle="denmark" continent="europe" iso="208">Denmark</country>
+  <country code="dj" handle="djibouti" continent="africa" iso="262">Djibouti</country>
+  <country code="dm" handle="dominica" continent="central america" iso="212">Dominica</country>
+  <country code="do" handle="dominican-republic" continent="central america" iso="214">Dominican Republic</country>
+  <country code="ec" handle="ecuador" continent="africa" iso="218">Ecuador</country>
+  <country code="eg" handle="egypt" continent="africa" iso="818">Egypt</country>
+  <country code="sv" handle="el-salvador" continent="central america" iso="222">El Salvador</country>
+  <country code="gq" handle="equatorial-guinea" continent="africa" iso="226">Equatorial Guinea</country>
+  <country code="er" handle="eritrea" continent="africa" iso="232">Eritrea</country>
+  <country code="ee" handle="estonia" continent="europe" iso="233">Estonia</country>
+  <country code="et" handle="ethiopia" continent="africa" iso="210">Ethiopia</country>
+  <country code="fk" handle="falkland-islands" continent="south america" iso="238">Falkland Islands (Malvinas)</country>
+  <country code="fo" handle="faroe-islands" continent="europe" iso="234">Faroe Islands</country>
+  <country code="fj" handle="fiji" continent="melanesia" iso="242">Fiji</country>
+  <country code="fi" handle="finland" continent="europe" iso="246">Finland</country>
+  <country code="fr" handle="france" continent="europe" alt="Francaise" iso="250">France</country>
+  <country code="fx" handle="france-metropolitan" continent="europe" iso="249">France, Metropolitan</country>
+  <country code="gf" handle="french-guiana" continent="south america" iso="254">French Guiana</country>
+  <country code="pf" handle="french-polynesia" continent="polynesia" iso="258">French Polynesia</country>
+  <country code="tf" handle="french-southern-territories" continent="antarctica" iso="260">French Southern Territories
+  </country>
+  <country code="ga" handle="gabon" continent="africa" iso="266">Gabon</country>
+  <country code="gm" handle="gambia" continent="africa" iso="270">Gambia</country>
+  <country code="ge" handle="georgia" continent="asia" iso="268">Georgia</country>
+  <country code="de" handle="germany" continent="europe" alt="Deutschland" iso="276">Germany</country>
+  <country code="gh" handle="ghana" continent="africa" iso="288">Ghana</country>
+  <country code="gi" handle="gibraltar" continent="europe" iso="292">Gibraltar</country>
+  <country code="gr" handle="greece" continent="europe" iso="300">Greece</country>
+  <country code="gl" handle="greenland" continent="north america" iso="304">Greenland</country>
+  <country code="gd" handle="grenada" continent="north america" iso="308">Grenada</country>
+  <country code="gp" handle="guadeloupe" continent="north america" iso="312">Guadeloupe</country>
+  <country code="gu" handle="guam" continent="australasia" iso="316">Guam</country>
+  <country code="gt" handle="guatemala" continent="north america" iso="320">Guatemala</country>
+  <country code="gn" handle="guinea" continent="africa" iso="324">Guinea</country>
+  <country code="gw" handle="guinea-bissau" continent="africa" iso="624">Guinea-Bissau</country>
+  <country code="gy" handle="guyana" continent="south america" iso="328">Guyana</country>
+  <country code="ht" handle="haiti" continent="north america" iso="332">Haiti</country>
+  <country code="hm" handle="heard-island-and-mcdonald-islands" continent="antarctica" iso="334">Heard Island and
+    Mcdonald Islands
+  </country>
+  <country code="hn" handle="honduras" continent="north america" iso="340">Honduras</country>
+  <country code="hk" handle="hong-kong" continent="asia" iso="344">Hong Kong</country>
+  <country code="hu" handle="hungary" continent="europe" iso="348">Hungary</country>
+  <country code="is" handle="iceland" continent="europe" iso="352">Iceland</country>
+  <country code="in" handle="india" continent="asia" iso="356">India</country>
+  <country code="id" handle="indonesia" continent="asia" iso="360">Indonesia</country>
+  <country code="ir" handle="iran-islamic-republic-of" continent="asia" iso="364">Iran, Islamic Republic Of</country>
+  <country code="iq" handle="iraq" continent="asia" iso="368">Iraq</country>
+  <country code="ie" handle="ireland" continent="europe" iso="372">Ireland</country>
+  <country code="il" handle="israel" continent="asia" iso="376">Israel</country>
+  <country code="it" handle="italy" continent="europe" iso="380">Italy</country>
+  <country code="jm" handle="jamaica" continent="north america" iso="388">Jamaica</country>
+  <country code="jp" handle="japan" continent="asia" iso="392">Japan</country>
+  <country code="jo" handle="jordan" continent="asia" iso="400">Jordan</country>
+  <country code="kz" handle="kazakhstan" continent="asia" iso="398">Kazakhstan</country>
+  <country code="ke" handle="kenya" continent="africa" iso="404">Kenya</country>
+  <country code="ki" handle="kiribati" continent="australasia" iso="296">Kiribati</country>
+  <country code="kp" handle="korea-democratic-peoples-republic-of" continent="asia" alt="dprk" iso="408">Korea,
+    Democratic People"S Republic Of
+  </country>
+  <country code="kr" handle="korea-republic-of" continent="asia" iso="410">Korea, Republic Of</country>
+  <country code="kw" handle="kuwait" continent="asia" iso="414">Kuwait</country>
+  <country code="kg" handle="kyrgyzstan" continent="asia" iso="417">Kyrgyzstan</country>
+  <country code="la" handle="lao-peoples-democratic-republic" continent="asia" iso="418">Lao People"s Democratic
+    Republic
+  </country>
+  <country code="lv" handle="latvia" continent="europe" iso="428">Latvia</country>
+  <country code="lb" handle="lebanon" continent="asia" iso="422">Lebanon</country>
+  <country code="ls" handle="lesotho" continent="africa" iso="426">Lesotho</country>
+  <country code="lr" handle="liberia" continent="africa" iso="430">Liberia</country>
+  <country code="ly" handle="libyan-arab-jamahiriya" continent="africa" iso="434">Libyan Arab Jamahiriya</country>
+  <country code="li" handle="liechtenstein" continent="europe" iso="438">Liechtenstein</country>
+  <country code="lt" handle="lithuania" continent="europe" iso="440">Lithuania</country>
+  <country code="lu" handle="luxembourg" continent="europe" iso="442">Luxembourg</country>
+  <country code="mo" handle="macau" continent="asia" iso="446">Macau</country>
+  <country code="mk" handle="macedonia-the-former-yugoslav-republic-of" continent="europe" iso="807">Macedonia, The
+    Former Yugoslav Republic Of
+  </country>
+  <country code="mg" handle="madagascar" continent="africa" iso="450">Madagascar</country>
+  <country code="mw" handle="malawi" continent="africa" iso="454">Malawi</country>
+  <country code="my" handle="malaysia" continent="asia" iso="458">Malaysia</country>
+  <country code="mv" handle="maldives" continent="asia" iso="462">Maldives</country>
+  <country code="ml" handle="mali" continent="africa" iso="466">Mali</country>
+  <country code="mt" handle="malta" continent="europe" iso="470">Malta</country>
+  <country code="mh" handle="marshall-islands" continent="australasia" iso="584">Marshall Islands</country>
+  <country code="mq" handle="martinique" continent="north america" iso="474">Martinique</country>
+  <country code="mr" handle="mauritania" continent="africa" iso="478">Mauritania</country>
+  <country code="mu" handle="mauritius" continent="africa" iso="480">Mauritius</country>
+  <country code="yt" handle="mayotte" continent="africa" iso="175">Mayotte</country>
+  <country code="mx" handle="mexico" continent="north america" iso="484">Mexico</country>
+  <country code="fm" handle="micronesia-federated-states-of" continent="micronesia" iso="583">Micronesia, Federated
+    States Of
+  </country>
+  <country code="md" handle="moldova-republic-of" continent="europe" iso="498">Moldova, Republic Of</country>
+  <country code="mc" handle="monaco" continent="europe" iso="492">Monaco</country>
+  <country code="mn" handle="mongolia" continent="asia" iso="496">Mongolia</country>
+  <country code="ms" handle="montserrat" continent="north america" iso="500">Montserrat</country>
+  <country code="ma" handle="morocco" continent="africa" iso="504">Morocco</country>
+  <country code="mz" handle="mozambique" continent="africa" iso="508">Mozambique</country>
+  <country code="mm" handle="myanmar" continent="asia" iso="104">Myanmar</country>
+  <country code="na" handle="namibia" continent="africa" iso="516">Namibia</country>
+  <country code="nr" handle="nauru" continent="australasia" iso="520">Nauru</country>
+  <country code="np" handle="nepal" continent="asia" iso="524">Nepal</country>
+  <country code="nl" handle="netherlands" continent="europe" alt="Nederlands NL Holland" iso="528">Netherlands</country>
+  <country code="an" handle="netherlands-antilles" continent="north america" iso="530">Netherlands Antilles</country>
+  <country code="nc" handle="new-caledonia" continent="australasia" iso="540">New Caledonia</country>
+  <country code="nz" handle="new-zealand" continent="australasia" iso="554">New Zealand</country>
+  <country code="ni" handle="nicaragua" continent="north america" iso="558">Nicaragua</country>
+  <country code="ne" handle="niger" continent="africa" iso="562">Niger</country>
+  <country code="ng" handle="nigeria" continent="africa" iso="566">Nigeria</country>
+  <country code="nu" handle="niue" continent="polynesia" iso="570">Niue</country>
+  <country code="nf" handle="norfolk-island" continent="australasia" iso="574">Norfolk Island</country>
+  <country code="mp" handle="northern-mariana-islands" continent="australasia" iso="580">Northern Mariana Islands
+  </country>
+  <country code="no" handle="norway" continent="europe" iso="578">Norway</country>
+  <country code="om" handle="oman" continent="asia" iso="512">Oman</country>
+  <country code="pk" handle="pakistan" continent="asia" iso="586">Pakistan</country>
+  <country code="pw" handle="palau" continent="asia" iso="585">Palau</country>
+  <country code="pa" handle="panama" continent="central america" iso="591">Panama</country>
+  <country code="pg" handle="papua-new-guinea" continent="melanesia" iso="598">Papua New Guinea</country>
+  <country code="py" handle="paraguay" continent="south america" iso="600">Paraguay</country>
+  <country code="pe" handle="peru" continent="south america" iso="604">Peru</country>
+  <country code="ph" handle="philippines" continent="asia" iso="608">Philippines</country>
+  <country code="pn" handle="pitcairn" continent="australasia" iso="612">Pitcairn</country>
+  <country code="pl" handle="poland" continent="europe" iso="616">Poland</country>
+  <country code="pt" handle="portugal" continent="europe" iso="620">Portugal</country>
+  <country code="pr" handle="puerto-rico" continent="south america" iso="630">Puerto Rico</country>
+  <country code="qa" handle="qatar" continent="asia" iso="634">Qatar</country>
+  <country code="re" handle="reunion" continent="africa" iso="638">Reunion</country>
+  <country code="ro" handle="romania" continent="europe" iso="642">Romania</country>
+  <country code="ru" handle="russian-federation" continent="asia" alt="Pocc" iso="643">Russian Federation</country>
+  <country code="rw" handle="rwanda" continent="africa" iso="646">Rwanda</country>
+  <country code="sh" handle="saint-helena" continent="none" iso="654">Saint Helena</country>
+  <country code="kn" handle="saint-kitts-and-nevis" continent="north america" iso="659">Saint Kitts And Nevis</country>
+  <country code="lc" handle="saint-lucia" continent="north america" iso="662">Saint Lucia</country>
+  <country code="pm" handle="saint-pierre-and-miquelon" continent="north america" iso="666">Saint Pierre And Miquelon
+  </country>
+  <country code="vc" handle="saint-vincent-and-the-grenadines" continent="north america" iso="670">Saint Vincent And The
+    Grenadines
+  </country>
+  <country code="ws" handle="samoa" continent="africa" iso="882">Samoa</country>
+  <country code="sm" handle="san-marino" continent="europe" iso="674">San Marino</country>
+  <country code="st" handle="sao-tome-and-principe" continent="africa" iso="678">Sao Tome And Principe</country>
+  <country code="sa" handle="saudi-arabia" continent="asia" iso="682">Saudi Arabia</country>
+  <country code="sn" handle="senegal" continent="africa" iso="686">Senegal</country>
+  <country code="sc" handle="seychelles" continent="africa" iso="690">Seychelles</country>
+  <country code="sl" handle="sierra-leone" continent="africa" iso="694">Sierra Leone</country>
+  <country code="sg" handle="singapore" continent="asia" iso="702">Singapore</country>
+  <country code="sk" handle="slovakia" continent="europe" iso="703">Slovakia (Slovak Republic)</country>
+  <country code="si" handle="slovenia" continent="europe" iso="705">Slovenia</country>
+  <country code="sb" handle="solomon-islands" continent="australasia" iso="90">Solomon Islands</country>
+  <country code="so" handle="somalia" continent="africa" iso="706">Somalia</country>
+  <country code="za" handle="south-africa" continent="africa" iso="710">South Africa</country>
+  <country code="es" handle="spain" continent="europe" alt="Espana" iso="724">Spain</country>
+  <country code="lk" handle="sri-lanka" continent="asia" iso="144">Sri Lanka</country>
+  <country code="sd" handle="sudan" continent="africa" iso="736">Sudan</country>
+  <country code="sr" handle="suriname" continent="south america" iso="740">Suriname</country>
+  <country code="sj" handle="svalbard-and-jan-mayen-islands" continent="europe" iso="744">Svalbard And Jan Mayen
+    Islands
+  </country>
+  <country code="sz" handle="swaziland" continent="africa" iso="748">Swaziland</country>
+  <country code="se" handle="sweden" continent="europe" iso="752">Sweden</country>
+  <country code="ch" handle="switzerland" continent="europe" iso="756">Switzerland</country>
+  <country code="sy" handle="syrian-arab-republic" continent="asia" iso="760">Syrian Arab Republic</country>
+  <country code="tw" handle="taiwan-province-of-china" continent="asia" iso="158">Taiwan, Province Of China</country>
+  <country code="tj" handle="tajikistan" continent="asia" iso="762">Tajikistan</country>
+  <country code="tz" handle="tanzania-united-republic-of" continent="africa" iso="834">Tanzania, United Republic Of
+  </country>
+  <country code="th" handle="thailand" continent="asia" iso="764">Thailand</country>
+  <country code="tg" handle="togo" continent="africa" iso="768">Togo</country>
+  <country code="tk" handle="tokelau" continent="australasia" iso="772">Tokelau</country>
+  <country code="to" handle="tonga" continent="polynesia" iso="776">Tonga</country>
+  <country code="tt" handle="trinidad-and-tobago" continent="north america" iso="780">Trinidad And Tobago</country>
+  <country code="tn" handle="tunisia" continent="africa" iso="788">Tunisia</country>
+  <country code="tr" handle="turkey" continent="asia" iso="792">Turkey</country>
+  <country code="tm" handle="turkmenistan" continent="asia" iso="795">Turkmenistan</country>
+  <country code="tc" handle="turks-and-caicos-islands" continent="north america" iso="796">Turks And Caicos Islands
+  </country>
+  <country code="tv" handle="tuvalu" continent="polynesia" iso="798">Tuvalu</country>
+  <country code="ug" handle="uganda" continent="africa" iso="800">Uganda</country>
+  <country code="ua" handle="ukraine" continent="europe" iso="804">Ukraine</country>
+  <country code="ae" handle="united-arab-emirates" continent="asia" iso="784">United Arab Emirates</country>
+  <country code="gb" handle="united-kingdom" continent="europe" alt="England Scotland Wales GB UK Great Britain Britain Northern" boost="3" iso="826">
+    United Kingdom
+  </country>
+  <country code="us" handle="united-states" continent="north america" alt="US America USA" boost="2" iso="840">United
+    States
+  </country>
+  <country code="um" handle="united-states-minor-outlying-islands" continent="north america" iso="581">United States
+    Minor Outlying Islands
+  </country>
+  <country code="uy" handle="uruguay" continent="south america" iso="858">Uruguay</country>
+  <country code="uz" handle="uzbekistan" continent="asia" iso="860">Uzbekistan</country>
+  <country code="vu" handle="vanuatu" continent="australasia" iso="548">Vanuatu</country>
+  <country code="va" handle="vatican-city-state" continent="europe" iso="336">Vatican City State (Holy See)</country>
+  <country code="ve" handle="venezuela" continent="south america" iso="862">Venezuela</country>
+  <country code="vn" handle="vietnam" continent="asia" iso="704">Vietnam</country>
+  <country code="vg" handle="virgin-islands-uk" continent="europe" iso="92">Virgin Islands (British)</country>
+  <country code="vi" handle="virgin-islands-us" continent="north america" iso="850">Virgin Islands (U.S.)</country>
+  <country code="wf" handle="wallis-and-futuna-islands" continent="polynesia" iso="876">Wallis And Futuna Islands
+  </country>
+  <country code="eh" handle="western-sahara" continent="africa" iso="732">Western Sahara</country>
+  <country code="ye" handle="yemen" continent="asia" iso="887">Yemen</country>
+  <country code="yu" handle="yugoslavia" continent="europe" iso="891">Yugoslavia</country>
+  <country code="zr" handle="zaire" continent="africa" iso="180">Zaire</country>
+  <country code="zm" handle="zambia" continent="africa" iso="894">Zambia</country>
+  <country code="zw" handle="zimbabwe" continent="africa" iso="716">Zimbabwe</country>
+</countries>

--- a/src/test/resources/fullcountries.xml
+++ b/src/test/resources/fullcountries.xml
@@ -1,0 +1,264 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<countries>
+  <continent name="asia">
+    <country code="af" handle="afghanistan" iso="4" name="Afghanistan"/>
+    <country code="bh" handle="bahrain" iso="48" name="Bahrain"/>
+    <country code="bd" handle="bangladesh" iso="50" name="Bangladesh"/>
+    <country code="bt" handle="bhutan" iso="64" name="Bhutan"/>
+    <country code="io" handle="british-indian-ocean-continent" iso="86" name="British Indian Ocean continent"/>
+    <country code="bn" handle="brunei-darussalam" iso="96" name="Brunei Darussalam"/>
+    <country code="kh" handle="cambodia" iso="116" name="Cambodia"/>
+    <country code="cn" handle="china" iso="156" name="China"/>
+    <country code="ge" handle="georgia" iso="268" name="Georgia"/>
+    <country code="hk" handle="hong-kong" iso="344" name="Hong Kong"/>
+    <country code="in" handle="india" iso="356" name="India"/>
+    <country code="id" handle="indonesia" iso="360" name="Indonesia"/>
+    <country code="ir" handle="iran-islamic-republic-of" iso="364" name="Iran, Islamic Republic Of"/>
+    <country code="iq" handle="iraq" iso="368" name="Iraq"/>
+    <country code="il" handle="israel" iso="376" name="Israel"/>
+    <country code="jp" handle="japan" iso="392" name="Japan"/>
+    <country code="jo" handle="jordan" iso="400" name="Jordan"/>
+    <country code="kz" handle="kazakhstan" iso="398" name="Kazakhstan"/>
+    <country alt="dprk" code="kp" handle="korea-democratic-peoples-republic-of" iso="408" name="Korea, Democratic People&quot;S Republic Of"/>
+    <country code="kr" handle="korea-republic-of" iso="410" name="Korea, Republic Of"/>
+    <country code="kw" handle="kuwait" iso="414" name="Kuwait"/>
+    <country code="kg" handle="kyrgyzstan" iso="417" name="Kyrgyzstan"/>
+    <country code="la" handle="lao-peoples-democratic-republic" iso="418" name="Lao People&quot;s Democratic Republic"/>
+    <country code="lb" handle="lebanon" iso="422" name="Lebanon"/>
+    <country code="mo" handle="macau" iso="446" name="Macau"/>
+    <country code="my" handle="malaysia" iso="458" name="Malaysia"/>
+    <country code="mv" handle="maldives" iso="462" name="Maldives"/>
+    <country code="mn" handle="mongolia" iso="496" name="Mongolia"/>
+    <country code="mm" handle="myanmar" iso="104" name="Myanmar"/>
+    <country code="np" handle="nepal" iso="524" name="Nepal"/>
+    <country code="om" handle="oman" iso="512" name="Oman"/>
+    <country code="pk" handle="pakistan" iso="586" name="Pakistan"/>
+    <country code="pw" handle="palau" iso="585" name="Palau"/>
+    <country code="ph" handle="philippines" iso="608" name="Philippines"/>
+    <country code="qa" handle="qatar" iso="634" name="Qatar"/>
+    <country alt="Pocc" code="ru" handle="russian-federation" iso="643" name="Russian Federation"/>
+    <country code="sa" handle="saudi-arabia" iso="682" name="Saudi Arabia"/>
+    <country code="sg" handle="singapore" iso="702" name="Singapore"/>
+    <country code="lk" handle="sri-lanka" iso="144" name="Sri Lanka"/>
+    <country code="sy" handle="syrian-arab-republic" iso="760" name="Syrian Arab Republic"/>
+    <country code="tw" handle="taiwan-province-of-china" iso="158" name="Taiwan, Province Of China"/>
+    <country code="tj" handle="tajikistan" iso="762" name="Tajikistan"/>
+    <country code="th" handle="thailand" iso="764" name="Thailand"/>
+    <country code="tr" handle="turkey" iso="792" name="Turkey"/>
+    <country code="tm" handle="turkmenistan" iso="795" name="Turkmenistan"/>
+    <country code="ae" handle="united-arab-emirates" iso="784" name="United Arab Emirates"/>
+    <country code="uz" handle="uzbekistan" iso="860" name="Uzbekistan"/>
+    <country code="vn" handle="vietnam" iso="704" name="Vietnam"/>
+    <country code="ye" handle="yemen" iso="887" name="Yemen"/>
+  </continent>
+  <continent name="europe">
+    <country code="al" handle="albania" iso="8" name="Albania"/>
+    <country code="ad" handle="andorra" iso="20" name="Andorra"/>
+    <country code="am" handle="armenia" iso="51" name="Armenia"/>
+    <country code="at" handle="austria" iso="40" name="Austria"/>
+    <country code="az" handle="azerbaijan" iso="31" name="Azerbaijan"/>
+    <country code="by" handle="belarus" iso="112" name="Belarus"/>
+    <country code="be" handle="belgium" iso="56" name="Belgium"/>
+    <country code="ba" handle="bosnia-and-herzegovina" iso="70" name="Bosnia And Herzegovina"/>
+    <country code="bg" handle="bulgaria" iso="100" name="Bulgaria"/>
+    <country code="hr" handle="croatia" iso="191" name="Croatia"/>
+    <country code="cy" handle="cyprus" iso="196" name="Cyprus"/>
+    <country code="cz" handle="czech-republic" iso="203" name="Czech Republic"/>
+    <country code="dk" handle="denmark" iso="208" name="Denmark"/>
+    <country code="ee" handle="estonia" iso="233" name="Estonia"/>
+    <country code="fo" handle="faroe-islands" iso="234" name="Faroe Islands"/>
+    <country code="fi" handle="finland" iso="246" name="Finland"/>
+    <country alt="Francaise" code="fr" handle="france" iso="250" name="France"/>
+    <country code="fx" handle="france-metropolitan" iso="249" name="France, Metropolitan"/>
+    <country alt="Deutschland" code="de" handle="germany" iso="276" name="Germany"/>
+    <country code="gi" handle="gibraltar" iso="292" name="Gibraltar"/>
+    <country code="gr" handle="greece" iso="300" name="Greece"/>
+    <country code="hu" handle="hungary" iso="348" name="Hungary"/>
+    <country code="is" handle="iceland" iso="352" name="Iceland"/>
+    <country code="ie" handle="ireland" iso="372" name="Ireland"/>
+    <country code="it" handle="italy" iso="380" name="Italy"/>
+    <country code="lv" handle="latvia" iso="428" name="Latvia"/>
+    <country code="li" handle="liechtenstein" iso="438" name="Liechtenstein"/>
+    <country code="lt" handle="lithuania" iso="440" name="Lithuania"/>
+    <country code="lu" handle="luxembourg" iso="442" name="Luxembourg"/>
+    <country code="mk" handle="macedonia-the-former-yugoslav-republic-of" iso="807" name="Macedonia, The Former Yugoslav Republic Of"/>
+    <country code="mt" handle="malta" iso="470" name="Malta"/>
+    <country code="md" handle="moldova-republic-of" iso="498" name="Moldova, Republic Of"/>
+    <country code="mc" handle="monaco" iso="492" name="Monaco"/>
+    <country alt="Nederlands NL Holland" code="nl" handle="netherlands" iso="528" name="Netherlands"/>
+    <country code="no" handle="norway" iso="578" name="Norway"/>
+    <country code="pl" handle="poland" iso="616" name="Poland"/>
+    <country code="pt" handle="portugal" iso="620" name="Portugal"/>
+    <country code="ro" handle="romania" iso="642" name="Romania"/>
+    <country code="sm" handle="san-marino" iso="674" name="San Marino"/>
+    <country code="sk" handle="slovakia" iso="703" name="Slovakia (Slovak Republic)"/>
+    <country code="si" handle="slovenia" iso="705" name="Slovenia"/>
+    <country alt="Espana" code="es" handle="spain" iso="724" name="Spain"/>
+    <country code="sj" handle="svalbard-and-jan-mayen-islands" iso="744" name="Svalbard And Jan Mayen Islands"/>
+    <country code="se" handle="sweden" iso="752" name="Sweden"/>
+    <country code="ch" handle="switzerland" iso="756" name="Switzerland"/>
+    <country code="ua" handle="ukraine" iso="804" name="Ukraine"/>
+    <country alt="England Scotland Wales GB UK Great Britain Britain Northern" boost="3" code="gb" handle="united-kingdom" iso="826" name="United Kingdom"/>
+    <country code="va" handle="vatican-city-state" iso="336" name="Vatican City State (Holy See)"/>
+    <country code="vg" handle="virgin-islands-uk" iso="92" name="Virgin Islands (British)"/>
+    <country code="yu" handle="yugoslavia" iso="891" name="Yugoslavia"/>
+  </continent>
+  <continent name="africa">
+    <country code="dz" handle="algeria" iso="12" name="Algeria"/>
+    <country code="ao" handle="angola" iso="24" name="Angola"/>
+    <country code="bj" handle="benin" iso="204" name="Benin"/>
+    <country code="bw" handle="botswana" iso="72" name="Botswana"/>
+    <country code="bf" handle="burkina-faso" iso="854" name="Burkina Faso"/>
+    <country code="bi" handle="burundi" iso="108" name="Burundi"/>
+    <country code="cm" handle="cameroon" iso="120" name="Cameroon"/>
+    <country code="cv" handle="cape-verde" iso="132" name="Cape Verde"/>
+    <country code="cf" handle="central-african-republic" iso="140" name="Central African Republic"/>
+    <country code="td" handle="chad" iso="148" name="Chad"/>
+    <country code="km" handle="comoros" iso="174" name="Comoros"/>
+    <country code="cg" handle="congo" iso="178" name="Congo"/>
+    <country code="ci" handle="cote-divoire" iso="384" name="Cote D&quot;Ivoire"/>
+    <country code="dj" handle="djibouti" iso="262" name="Djibouti"/>
+    <country code="ec" handle="ecuador" iso="218" name="Ecuador"/>
+    <country code="eg" handle="egypt" iso="818" name="Egypt"/>
+    <country code="gq" handle="equatorial-guinea" iso="226" name="Equatorial Guinea"/>
+    <country code="er" handle="eritrea" iso="232" name="Eritrea"/>
+    <country code="et" handle="ethiopia" iso="210" name="Ethiopia"/>
+    <country code="ga" handle="gabon" iso="266" name="Gabon"/>
+    <country code="gm" handle="gambia" iso="270" name="Gambia"/>
+    <country code="gh" handle="ghana" iso="288" name="Ghana"/>
+    <country code="gn" handle="guinea" iso="324" name="Guinea"/>
+    <country code="gw" handle="guinea-bissau" iso="624" name="Guinea-Bissau"/>
+    <country code="ke" handle="kenya" iso="404" name="Kenya"/>
+    <country code="ls" handle="lesotho" iso="426" name="Lesotho"/>
+    <country code="lr" handle="liberia" iso="430" name="Liberia"/>
+    <country code="ly" handle="libyan-arab-jamahiriya" iso="434" name="Libyan Arab Jamahiriya"/>
+    <country code="mg" handle="madagascar" iso="450" name="Madagascar"/>
+    <country code="mw" handle="malawi" iso="454" name="Malawi"/>
+    <country code="ml" handle="mali" iso="466" name="Mali"/>
+    <country code="mr" handle="mauritania" iso="478" name="Mauritania"/>
+    <country code="mu" handle="mauritius" iso="480" name="Mauritius"/>
+    <country code="yt" handle="mayotte" iso="175" name="Mayotte"/>
+    <country code="ma" handle="morocco" iso="504" name="Morocco"/>
+    <country code="mz" handle="mozambique" iso="508" name="Mozambique"/>
+    <country code="na" handle="namibia" iso="516" name="Namibia"/>
+    <country code="ne" handle="niger" iso="562" name="Niger"/>
+    <country code="ng" handle="nigeria" iso="566" name="Nigeria"/>
+    <country code="re" handle="reunion" iso="638" name="Reunion"/>
+    <country code="rw" handle="rwanda" iso="646" name="Rwanda"/>
+    <country code="ws" handle="samoa" iso="882" name="Samoa"/>
+    <country code="st" handle="sao-tome-and-principe" iso="678" name="Sao Tome And Principe"/>
+    <country code="sn" handle="senegal" iso="686" name="Senegal"/>
+    <country code="sc" handle="seychelles" iso="690" name="Seychelles"/>
+    <country code="sl" handle="sierra-leone" iso="694" name="Sierra Leone"/>
+    <country code="so" handle="somalia" iso="706" name="Somalia"/>
+    <country code="za" handle="south-africa" iso="710" name="South Africa"/>
+    <country code="sd" handle="sudan" iso="736" name="Sudan"/>
+    <country code="sz" handle="swaziland" iso="748" name="Swaziland"/>
+    <country code="tz" handle="tanzania-united-republic-of" iso="834" name="Tanzania, United Republic Of"/>
+    <country code="tg" handle="togo" iso="768" name="Togo"/>
+    <country code="tn" handle="tunisia" iso="788" name="Tunisia"/>
+    <country code="ug" handle="uganda" iso="800" name="Uganda"/>
+    <country code="eh" handle="western-sahara" iso="732" name="Western Sahara"/>
+    <country code="zr" handle="zaire" iso="180" name="Zaire"/>
+    <country code="zm" handle="zambia" iso="894" name="Zambia"/>
+    <country code="zw" handle="zimbabwe" iso="716" name="Zimbabwe"/>
+  </continent>
+  <continent name="polynesia">
+    <country code="as" handle="american-samoa" iso="16" name="American Samoa"/>
+    <country code="ck" handle="cook-islands" iso="184" name="Cook Islands"/>
+    <country code="pf" handle="french-polynesia" iso="258" name="French Polynesia"/>
+    <country code="nu" handle="niue" iso="570" name="Niue"/>
+    <country code="to" handle="tonga" iso="776" name="Tonga"/>
+    <country code="tv" handle="tuvalu" iso="798" name="Tuvalu"/>
+    <country code="wf" handle="wallis-and-futuna-islands" iso="876" name="Wallis And Futuna Islands"/>
+  </continent>
+  <continent name="north america">
+    <country code="ai" handle="anguilla" iso="660" name="Anguilla"/>
+    <country code="ag" handle="antigua-and-barbuda" iso="28" name="Antigua And Barbuda"/>
+    <country code="aw" handle="aruba" iso="533" name="Aruba"/>
+    <country code="bs" handle="bahamas" iso="44" name="Bahamas"/>
+    <country code="bb" handle="barbados" iso="52" name="Barbados"/>
+    <country code="bm" handle="bermuda" iso="60" name="Bermuda"/>
+    <country code="ca" handle="canada" iso="124" name="Canada"/>
+    <country code="ky" handle="cayman-islands" iso="136" name="Cayman Islands"/>
+    <country code="gl" handle="greenland" iso="304" name="Greenland"/>
+    <country code="gd" handle="grenada" iso="308" name="Grenada"/>
+    <country code="gp" handle="guadeloupe" iso="312" name="Guadeloupe"/>
+    <country code="gt" handle="guatemala" iso="320" name="Guatemala"/>
+    <country code="ht" handle="haiti" iso="332" name="Haiti"/>
+    <country code="hn" handle="honduras" iso="340" name="Honduras"/>
+    <country code="jm" handle="jamaica" iso="388" name="Jamaica"/>
+    <country code="mq" handle="martinique" iso="474" name="Martinique"/>
+    <country code="mx" handle="mexico" iso="484" name="Mexico"/>
+    <country code="ms" handle="montserrat" iso="500" name="Montserrat"/>
+    <country code="an" handle="netherlands-antilles" iso="530" name="Netherlands Antilles"/>
+    <country code="ni" handle="nicaragua" iso="558" name="Nicaragua"/>
+    <country code="kn" handle="saint-kitts-and-nevis" iso="659" name="Saint Kitts And Nevis"/>
+    <country code="lc" handle="saint-lucia" iso="662" name="Saint Lucia"/>
+    <country code="pm" handle="saint-pierre-and-miquelon" iso="666" name="Saint Pierre And Miquelon"/>
+    <country code="vc" handle="saint-vincent-and-the-grenadines" iso="670" name="Saint Vincent And The Grenadines"/>
+    <country code="tt" handle="trinidad-and-tobago" iso="780" name="Trinidad And Tobago"/>
+    <country code="tc" handle="turks-and-caicos-islands" iso="796" name="Turks And Caicos Islands"/>
+    <country alt="US America USA" boost="2" code="us" handle="united-states" iso="840" name="United States"/>
+    <country code="um" handle="united-states-minor-outlying-islands" iso="581" name="United States Minor Outlying Islands"/>
+    <country code="vi" handle="virgin-islands-us" iso="850" name="Virgin Islands (U.S.)"/>
+  </continent>
+  <continent name="antarctica">
+    <country code="aq" handle="antarctica" iso="10" name="Antarctica"/>
+    <country code="bv" handle="bouvet-island" iso="74" name="Bouvet Island"/>
+    <country code="tf" handle="french-southern-territories" iso="260" name="French Southern Territories"/>
+    <country code="hm" handle="heard-island-and-mcdonald-islands" iso="334" name="Heard Island and Mcdonald Islands"/>
+  </continent>
+  <continent name="south america">
+    <country code="ar" handle="argentina" iso="32" name="Argentina"/>
+    <country code="bo" handle="bolivia" iso="68" name="Bolivia"/>
+    <country code="br" handle="brazil" iso="76" name="Brazil"/>
+    <country code="cl" handle="chile" iso="152" name="Chile"/>
+    <country code="co" handle="colombia" iso="170" name="Colombia"/>
+    <country code="fk" handle="falkland-islands" iso="238" name="Falkland Islands (Malvinas)"/>
+    <country code="gf" handle="french-guiana" iso="254" name="French Guiana"/>
+    <country code="gy" handle="guyana" iso="328" name="Guyana"/>
+    <country code="py" handle="paraguay" iso="600" name="Paraguay"/>
+    <country code="pe" handle="peru" iso="604" name="Peru"/>
+    <country code="pr" handle="puerto-rico" iso="630" name="Puerto Rico"/>
+    <country code="sr" handle="suriname" iso="740" name="Suriname"/>
+    <country code="uy" handle="uruguay" iso="858" name="Uruguay"/>
+    <country code="ve" handle="venezuela" iso="862" name="Venezuela"/>
+  </continent>
+  <continent name="australasia">
+    <country code="au" handle="australia" iso="36" name="Australia"/>
+    <country code="cx" handle="christmas-island" iso="162" name="Christmas Island"/>
+    <country code="cc" handle="cocos-islands" iso="166" name="Cocos (Keeling) Islands"/>
+    <country code="gu" handle="guam" iso="316" name="Guam"/>
+    <country code="ki" handle="kiribati" iso="296" name="Kiribati"/>
+    <country code="mh" handle="marshall-islands" iso="584" name="Marshall Islands"/>
+    <country code="nr" handle="nauru" iso="520" name="Nauru"/>
+    <country code="nc" handle="new-caledonia" iso="540" name="New Caledonia"/>
+    <country code="nz" handle="new-zealand" iso="554" name="New Zealand"/>
+    <country code="nf" handle="norfolk-island" iso="574" name="Norfolk Island"/>
+    <country code="mp" handle="northern-mariana-islands" iso="580" name="Northern Mariana Islands"/>
+    <country code="pn" handle="pitcairn" iso="612" name="Pitcairn"/>
+    <country code="sb" handle="solomon-islands" iso="90" name="Solomon Islands"/>
+    <country code="tk" handle="tokelau" iso="772" name="Tokelau"/>
+    <country code="vu" handle="vanuatu" iso="548" name="Vanuatu"/>
+  </continent>
+  <continent name="central america">
+    <country code="bz" handle="belize" iso="84" name="Belize"/>
+    <country code="cr" handle="costa-rica" iso="188" name="Costa Rica"/>
+    <country code="cu" handle="cuba" iso="192" name="Cuba"/>
+    <country code="dm" handle="dominica" iso="212" name="Dominica"/>
+    <country code="do" handle="dominican-republic" iso="214" name="Dominican Republic"/>
+    <country code="sv" handle="el-salvador" iso="222" name="El Salvador"/>
+    <country code="pa" handle="panama" iso="591" name="Panama"/>
+  </continent>
+  <continent name="melanesia">
+    <country code="fj" handle="fiji" iso="242" name="Fiji"/>
+    <country code="pg" handle="papua-new-guinea" iso="598" name="Papua New Guinea"/>
+  </continent>
+  <continent name="micronesia">
+    <country code="fm" handle="micronesia-federated-states-of" iso="583" name="Micronesia, Federated States Of"/>
+  </continent>
+  <continent name="none">
+    <country code="sh" handle="saint-helena" iso="654" name="Saint Helena"/>
+  </continent>
+</countries>


### PR DESCRIPTION
 - transactions are now synchronised globally by the canonical file path
   (for persistent contexts) or the hashcode of the dom Document
   instance
   - a global instance of the MutexSync class manages mutexes across all
     threads and automatically clears unused mutexes
 - add TestNG dependency and write unit tests
 - add ability to remove attributes from XmlElements
 - create UninitializedParent as a way for lazy XmlElements created by
   LazyContext#handleXPathResults to access their parent elements
   - parent is initialized and set on the child element as soon as
     needed
 - StaticXmlParser: create convenience method to create Document for
   InputStream
 - cleanup Events
   - split ElementChangingEvent into several events
 - add BindableContext implementation for the LazyContext
 - create copies of collections before iterating where high concurrency
   may be expected
 - make Order support any Comparable type instead of just sorting
   strings lexicographically
 - Conditions: add parentMatches() method to apply a predicate to the
   parent of the element
 - AbstractXmlElement: keep attributes in a map for faster access
 - remove some deprecated methods