### PR TITLE
improve MutexSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Java XML Persistence API
     <dependency>
       <groupId>net.robinfriedli</groupId>
       <artifactId>JXP</artifactId>
-      <version>2.0</version>
+      <version>2.0.1</version>
       <type>pom</type>
     </dependency>
 
@@ -20,7 +20,7 @@ Java XML Persistence API
 ## Gradle
 ```gradle
     dependencies {
-        implementation "net.robinfriedli:JXP:2.0"
+        implementation "net.robinfriedli:JXP:2.0.1"
     }
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 }
 
 group = "net.robinfriedli"
-version = "2.0"
+version = "2.0.1"
 description = "JXP"
 sourceCompatibility = "8"
 targetCompatibility = "8"

--- a/src/main/java/net/robinfriedli/jxp/exec/ReferenceCountedMutex.java
+++ b/src/main/java/net/robinfriedli/jxp/exec/ReferenceCountedMutex.java
@@ -18,8 +18,8 @@ public class ReferenceCountedMutex<T> {
         this.containingMap = containingMap;
     }
 
-    public void incrementRc() {
-        rc.incrementAndGet();
+    public synchronized int incrementRc() {
+        return rc.getAndIncrement();
     }
 
     /**
@@ -29,6 +29,8 @@ public class ReferenceCountedMutex<T> {
         int currentRc = rc.decrementAndGet();
 
         if (currentRc < 1) {
+            // decrement rc again to a negative number to mark the mutex as invalid
+            rc.decrementAndGet();
             return containingMap.remove(key) != null;
         }
 


### PR DESCRIPTION
 - handle race condition where MutexSync could retrieve a mutex from the
   map just before a thread removes it thus locking a mutex that is not
   actually used anymore, meaning future tasks locking the same key
   would not get synchronised properly
   - if Thread A decrements the rc to 0 and removes the mutex from the
     map just after Thread B retrieved the mutex from the map but before
     Thread B could increment the rc, Thread B would end up using the
     mutex that is actually not in the map anymore and would not get
     used by future tasks locking the same key
   - ReferenceCountedMutex#decrementRc now decrements the rc a second
     time to a negative value when removing the mutex from the map
     and ReferenceCountedMutex#incrementRc now runs synchronised to
     ensure the #decrementRc method does not run in parallel.
     ReferenceCountedMutex#incrementRc now returns the old rc value to
     check whether it is negative, in which case retrieving the mutex
     will be retried